### PR TITLE
refactor(build): extract BuildPage components following birthsigns pa…

### DIFF
--- a/src/features/build/components/BasicInfoCard.tsx
+++ b/src/features/build/components/BasicInfoCard.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
+import { Input } from '@/shared/ui/ui/input'
+import { Label } from '@/shared/ui/ui/label'
+
+interface BasicInfoCardProps {
+  name: string
+  notes: string
+  onNameChange: (name: string) => void
+  onNotesChange: (notes: string) => void
+  className?: string
+}
+
+/**
+ * Basic Information Card Component
+ * 
+ * Handles character name and notes input for the build page.
+ * This follows the birthsigns pattern of feature-specific components
+ * that delegate to shared UI components.
+ */
+export function BasicInfoCard({
+  name,
+  notes,
+  onNameChange,
+  onNotesChange,
+  className,
+}: BasicInfoCardProps) {
+  return (
+    <Card className={`mb-6 ${className || ''}`}>
+      <CardHeader>
+        <CardTitle>Basic Information</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <Label htmlFor="name">Character Name</Label>
+          <Input
+            id="name"
+            value={name}
+            onChange={e => onNameChange(e.target.value)}
+            placeholder="Enter character name..."
+          />
+        </div>
+        <div>
+          <Label htmlFor="notes">Notes</Label>
+          <textarea
+            id="notes"
+            value={notes}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              onNotesChange(e.target.value)
+            }
+            placeholder="Add character notes, roleplay details, or build explanations..."
+            rows={4}
+            className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+} 

--- a/src/features/build/components/BuildControls.tsx
+++ b/src/features/build/components/BuildControls.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Button } from '@/shared/ui/ui/button'
+import { RotateCcw } from 'lucide-react'
+import { BuildLinkShareButton } from './ShareBuildButton'
+
+interface BuildControlsProps {
+  onReset: () => void
+  className?: string
+}
+
+/**
+ * Build Controls Component
+ * 
+ * Handles the build control buttons (reset and share).
+ * This follows the birthsigns pattern of feature-specific components
+ * that delegate to shared UI components.
+ */
+export function BuildControls({
+  onReset,
+  className,
+}: BuildControlsProps) {
+  return (
+    <div className={`flex flex-wrap gap-2 mb-6 ${className || ''}`}>
+      <Button
+        variant="destructive"
+        size="sm"
+        className="text-destructive-foreground cursor-pointer hover:opacity-90"
+        onClick={onReset}
+      >
+        <RotateCcw className="w-4 h-4 mr-2" />
+        Reset Build
+      </Button>
+      <BuildLinkShareButton />
+    </div>
+  )
+} 

--- a/src/features/build/components/BuildSummaryCard.tsx
+++ b/src/features/build/components/BuildSummaryCard.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { 
+  GenericSummaryCard, 
+  createBuildSummaryItems 
+} from '@/shared/components/generic/SummaryCard'
+
+interface BuildSummaryCardProps {
+  build: {
+    race: string | null
+    stone: string | null
+    religion: string | null
+    traits: {
+      regular: string[]
+      bonus: string[]
+    }
+    traitLimits: {
+      regular: number
+      bonus: number
+    }
+  }
+  title?: string
+  layout?: 'grid' | 'list'
+  className?: string
+}
+
+/**
+ * Build Summary Card Component
+ * 
+ * Feature-specific wrapper around GenericSummaryCard that displays
+ * character build summary information.
+ * 
+ * This follows the birthsigns pattern of feature-specific wrappers
+ * around generic components for better separation of concerns.
+ */
+export function BuildSummaryCard({
+  build,
+  title = 'Build Summary',
+  layout = 'grid',
+  className,
+}: BuildSummaryCardProps) {
+  const summaryItems = createBuildSummaryItems(build)
+
+  return (
+    <GenericSummaryCard
+      title={title}
+      items={summaryItems}
+      layout={layout}
+      className={className}
+    />
+  )
+}
+
+/**
+ * Compact Build Summary Card
+ * 
+ * Specialized summary card for compact display in sidebars
+ * or smaller spaces.
+ */
+export function CompactBuildSummaryCard({
+  build,
+  className,
+}: {
+  build: BuildSummaryCardProps['build']
+  className?: string
+}) {
+  return (
+    <BuildSummaryCard
+      build={build}
+      title="Summary"
+      layout="list"
+      className={className}
+    />
+  )
+} 

--- a/src/features/build/components/ConfirmDialog.tsx
+++ b/src/features/build/components/ConfirmDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { GenericConfirmDialog } from '@/shared/components/generic/ConfirmDialog'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  message: string
+  variant?: 'warning' | 'info' | 'error' | 'success'
+  confirmText?: string
+  cancelText?: string
+  onConfirm: () => void
+  onCancel: () => void
+  className?: string
+}
+
+/**
+ * Confirm Dialog Component
+ * 
+ * Feature-specific wrapper around GenericConfirmDialog that provides
+ * consistent confirmation dialogs throughout the application.
+ * 
+ * This follows the birthsigns pattern of feature-specific wrappers
+ * around generic components for better separation of concerns.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  variant = 'warning',
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  className,
+}: ConfirmDialogProps) {
+  return (
+    <GenericConfirmDialog
+      open={open}
+      title={title}
+      message={message}
+      variant={variant}
+      confirmText={confirmText}
+      cancelText={cancelText}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      className={className}
+    />
+  )
+}
+
+/**
+ * Build Reset Confirmation Dialog
+ * 
+ * Specialized confirmation dialog for resetting character builds.
+ * This demonstrates how to create domain-specific dialog variants.
+ */
+export function BuildResetConfirmDialog({
+  open,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <ConfirmDialog
+      open={open}
+      title="Reset Build?"
+      message="This will clear all selections and start a new build. This action cannot be undone."
+      variant="warning"
+      confirmText="Confirm Reset"
+      cancelText="Cancel"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  )
+} 

--- a/src/features/build/components/ShareBuildButton.tsx
+++ b/src/features/build/components/ShareBuildButton.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { GenericShareButton } from '@/shared/components/generic/ShareButton'
+
+interface ShareBuildButtonProps {
+  link: string
+  variant?: 'default' | 'outline' | 'ghost'
+  size?: 'sm' | 'lg'
+  text?: string
+  onCopied?: () => void
+  className?: string
+}
+
+/**
+ * Share Build Button Component
+ * 
+ * Feature-specific wrapper around GenericShareButton that handles
+ * sharing character build links.
+ * 
+ * This follows the birthsigns pattern of feature-specific wrappers
+ * around generic components for better separation of concerns.
+ */
+export function ShareBuildButton({
+  link,
+  variant = 'outline',
+  size = 'sm',
+  text = 'Export / Share',
+  onCopied,
+  className,
+}: ShareBuildButtonProps) {
+  return (
+    <GenericShareButton
+      link={link}
+      variant={variant}
+      size={size}
+      text={text}
+      onCopied={onCopied}
+      className={className}
+    />
+  )
+}
+
+/**
+ * Build Link Share Button
+ * 
+ * Specialized share button that automatically gets the current
+ * build link from the window location.
+ */
+export function BuildLinkShareButton({
+  onCopied,
+  className,
+}: {
+  onCopied?: () => void
+  className?: string
+}) {
+  const currentLink = window.location.href
+
+  return (
+    <ShareBuildButton
+      link={currentLink}
+      onCopied={onCopied}
+      className={className}
+    />
+  )
+} 

--- a/src/features/build/components/TraitLimitConfigCard.tsx
+++ b/src/features/build/components/TraitLimitConfigCard.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { 
+  GenericConfigCard, 
+  ConfigInput, 
+  ConfigAlert 
+} from '@/shared/components/generic/ConfigCard'
+import { Info } from 'lucide-react'
+
+interface TraitLimitConfigCardProps {
+  regularLimit: number
+  bonusLimit: number
+  onRegularLimitChange: (value: number) => void
+  onBonusLimitChange: (value: number) => void
+  currentRegularCount: number
+  currentBonusCount: number
+  className?: string
+}
+
+/**
+ * Trait Limit Configuration Card
+ * 
+ * Feature-specific wrapper around GenericConfigCard that handles
+ * trait limit configuration for character builds.
+ * 
+ * This follows the birthsigns pattern of feature-specific wrappers
+ * around generic components for better separation of concerns.
+ */
+export function TraitLimitConfigCard({
+  regularLimit,
+  bonusLimit,
+  onRegularLimitChange,
+  onBonusLimitChange,
+  currentRegularCount,
+  currentBonusCount,
+  className,
+}: TraitLimitConfigCardProps) {
+  const isUsingCustomLimits = regularLimit !== 2 || bonusLimit !== 1
+
+  return (
+    <GenericConfigCard
+      title="Trait Limits Configuration"
+      description="Configure the number of traits your character can have"
+      icon={<Info className="h-4 w-4 text-muted-foreground" />}
+      className={className}
+    >
+      {/* Warning about MCM configuration */}
+      <ConfigAlert
+        type="warning"
+        title="Default configuration is 2 starting + 1 late game traits."
+        message="Increasing these limits requires corresponding MCM (Mod Configuration Menu) changes in-game. Make sure your MCM settings match these limits to avoid conflicts."
+      />
+
+      {/* Trait limit inputs */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ConfigInput
+          label="Starting Traits Limit"
+          value={regularLimit}
+          onChange={onRegularLimitChange}
+          min={0}
+          max={10}
+          currentCount={currentRegularCount}
+          type="regular"
+        />
+        <ConfigInput
+          label="Late Game Traits Limit"
+          value={bonusLimit}
+          onChange={onBonusLimitChange}
+          min={0}
+          max={5}
+          currentCount={currentBonusCount}
+          type="bonus"
+        />
+      </div>
+
+      {/* Custom limits warning */}
+      {isUsingCustomLimits && (
+        <ConfigAlert
+          type="info"
+          title={`Custom limits detected: ${regularLimit} starting + ${bonusLimit} late game traits.`}
+          message="Remember to update your MCM settings accordingly."
+        />
+      )}
+    </GenericConfigCard>
+  )
+} 

--- a/src/features/build/components/index.ts
+++ b/src/features/build/components/index.ts
@@ -1,0 +1,7 @@
+// Build Feature Components
+export { TraitLimitConfigCard } from './TraitLimitConfigCard'
+export { ConfirmDialog, BuildResetConfirmDialog } from './ConfirmDialog'
+export { ShareBuildButton, BuildLinkShareButton } from './ShareBuildButton'
+export { BuildSummaryCard, CompactBuildSummaryCard } from './BuildSummaryCard'
+export { BasicInfoCard } from './BasicInfoCard'
+export { BuildControls } from './BuildControls' 

--- a/src/features/build/hooks/index.ts
+++ b/src/features/build/hooks/index.ts
@@ -1,0 +1,2 @@
+// Build Feature Hooks
+export { useTraitLimits } from './useTraitLimits' 

--- a/src/features/build/hooks/useTraitLimits.ts
+++ b/src/features/build/hooks/useTraitLimits.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react'
+import { useCharacterBuild } from '@/shared/hooks/useCharacterBuild'
+
+/**
+ * Custom Hook for Trait Limit Management
+ * 
+ * Manages trait limit state and provides handlers for updating limits.
+ * This follows the birthsigns pattern of custom hooks for state management.
+ */
+export function useTraitLimits() {
+  const { build, updateBuild } = useCharacterBuild()
+  
+  const [regularLimit, setRegularLimit] = useState(build.traitLimits.regular)
+  const [bonusLimit, setBonusLimit] = useState(build.traitLimits.bonus)
+
+  const handleRegularLimitChange = useCallback((value: number) => {
+    setRegularLimit(value)
+    updateBuild({
+      traitLimits: { ...build.traitLimits, regular: value },
+    })
+  }, [build.traitLimits, updateBuild])
+
+  const handleBonusLimitChange = useCallback((value: number) => {
+    setBonusLimit(value)
+    updateBuild({
+      traitLimits: { ...build.traitLimits, bonus: value },
+    })
+  }, [build.traitLimits, updateBuild])
+
+  return {
+    regularLimit,
+    bonusLimit,
+    handleRegularLimitChange,
+    handleBonusLimitChange,
+    currentRegularCount: build.traits.regular.length,
+    currentBonusCount: build.traits.bonus.length,
+  }
+} 

--- a/src/pages/BuildPage.tsx
+++ b/src/pages/BuildPage.tsx
@@ -1,46 +1,31 @@
 import { RaceSelectionCard } from '@/features/races/components'
 import { TraitSelectionCard } from '@/features/traits/components'
 import { useCharacterBuild } from '@/shared/hooks/useCharacterBuild'
-import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
-import { Input } from '@/shared/ui/ui/input'
-import { Label } from '@/shared/ui/ui/label'
-import { AlertTriangle, Info, RotateCcw, Share2 } from 'lucide-react'
-import BuildPageDestinyCard from '@/features/destiny/components/BuildPageDestinyCard'
-import {  useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui/ui/tabs'
-import { Button } from '@/shared/ui/ui/button'
+import BuildPageDestinyCard from '@/features/destiny/components/BuildPageDestinyCard'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+// Import extracted components
+import { 
+  TraitLimitConfigCard,
+  BuildResetConfirmDialog,
+  BuildSummaryCard,
+  BasicInfoCard,
+  BuildControls
+} from '@/features/build/components'
+import { useTraitLimits } from '@/features/build/hooks'
 
 import React from 'react'
 
 export function BuildPage() {
-  const { build, setBuildName, setBuildNotes, updateBuild, resetBuild, setDestinyPath } =
+  const { build, setBuildName, setBuildNotes, resetBuild, setDestinyPath } =
     useCharacterBuild()
 
-  const [regularLimit, setRegularLimit] = useState(build.traitLimits.regular)
-  const [bonusLimit, setBonusLimit] = useState(build.traitLimits.bonus)
   const [showConfirm, setShowConfirm] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const traitLimits = useTraitLimits()
 
   const navigate = useNavigate()
-
-  const handleRegularLimitChange = (value: string) => {
-    const numValue = parseInt(value) || 0
-    setRegularLimit(numValue)
-    updateBuild({
-      traitLimits: { ...build.traitLimits, regular: numValue },
-    })
-  }
-
-  const handleBonusLimitChange = (value: string) => {
-    const numValue = parseInt(value) || 0
-    setBonusLimit(numValue)
-    updateBuild({
-      traitLimits: { ...build.traitLimits, bonus: numValue },
-    })
-  }
-
-  const isUsingCustomLimits = regularLimit !== 2 || bonusLimit !== 1
 
   return (
     <div className="container mx-auto p-6 space-y-6">
@@ -48,63 +33,16 @@ export function BuildPage() {
         <h1 className="text-3xl font-bold">Character Builder</h1>
       </div>
       {/* Build Controls Area */}
-      <div className="flex flex-wrap gap-2 mb-6">
-        <Button
-          variant="destructive"
-          size="sm"
-          className="text-destructive-foreground cursor-pointer hover:opacity-90"
-          onClick={() => setShowConfirm(true)}
-        >
-          <RotateCcw className="w-4 h-4 mr-2" />
-          Reset Build
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="cursor-pointer hover:opacity-90"
-          onClick={() => {
-            navigator.clipboard.writeText(window.location.href)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 1500)
-          }}
-        >
-          <Share2 className="w-4 h-4 mr-2" />
-          Export / Share
-        </Button>
-        {copied && (
-          <span className="text-green-600 text-sm ml-2">Link copied!</span>
-        )}
-      </div>
+      <BuildControls onReset={() => setShowConfirm(true)} />
       {/* Confirmation Dialog */}
-      {showConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-          <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-6 w-full max-w-xs space-y-4 border border-border">
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="text-yellow-600 dark:text-yellow-400 h-5 w-5" />
-              <span className="font-semibold">Reset Build?</span>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              This will clear all selections and start a new build. This action cannot be undone.
-            </p>
-            <div className="flex justify-end gap-2">
-              <Button variant="outline" size="sm" onClick={() => setShowConfirm(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                className="text-destructive-foreground cursor-pointer hover:opacity-90"
-                onClick={() => {
-                  resetBuild()
-                  setShowConfirm(false)
-                }}
-              >
-                Confirm Reset
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <BuildResetConfirmDialog
+        open={showConfirm}
+        onConfirm={() => {
+          resetBuild()
+          setShowConfirm(false)
+        }}
+        onCancel={() => setShowConfirm(false)}
+      />
 
       <Tabs defaultValue="build" className="w-full">
         <TabsList className="mb-4">
@@ -113,35 +51,12 @@ export function BuildPage() {
         </TabsList>
         <TabsContent value="build">
           {/* Basic Information (always below tabs) */}
-          <Card className="mb-6">
-            <CardHeader>
-              <CardTitle>Basic Information</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <Label htmlFor="name">Character Name</Label>
-                <Input
-                  id="name"
-                  value={build.name}
-                  onChange={e => setBuildName(e.target.value)}
-                  placeholder="Enter character name..."
-                />
-              </div>
-              <div>
-                <Label htmlFor="notes">Notes</Label>
-                <textarea
-                  id="notes"
-                  value={build.notes}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    setBuildNotes(e.target.value)
-                  }
-                  placeholder="Add character notes, roleplay details, or build explanations..."
-                  rows={4}
-                  className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                />
-              </div>
-            </CardContent>
-          </Card>
+          <BasicInfoCard
+            name={build.name}
+            notes={build.notes}
+            onNameChange={setBuildName}
+            onNotesChange={setBuildNotes}
+          />
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
             {/* Race Selection and Display */}
@@ -154,108 +69,18 @@ export function BuildPage() {
           <BuildPageDestinyCard navigate={navigate} />
 
           {/* Build Summary */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Build Summary</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                <div>
-                  <span className="font-medium">Race:</span>
-                  <div className="text-muted-foreground">
-                    {build.race || 'Not selected'}
-                  </div>
-                </div>
-                <div>
-                  <span className="font-medium">Birth Sign:</span>
-                  <div className="text-muted-foreground">
-                    {build.stone || 'Not selected'}
-                  </div>
-                </div>
-                <div>
-                  <span className="font-medium">Religion:</span>
-                  <div className="text-muted-foreground">
-                    {build.religion || 'Not selected'}
-                  </div>
-                </div>
-                <div>
-                  <span className="font-medium">Traits:</span>
-                  <div className="text-muted-foreground">
-                    {build.traits.regular.length}/{regularLimit} starting,{' '}
-                    {build.traits.bonus.length}/{bonusLimit} late game
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <BuildSummaryCard build={build} />
         </TabsContent>
         <TabsContent value="config">
           {/* Trait Limits Configuration */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                Trait Limits Configuration
-                <Info className="h-4 w-4 text-muted-foreground" />
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="flex items-start gap-2 p-4 rounded-lg border border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950">
-                <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400 mt-0.5 flex-shrink-0" />
-                <div className="text-sm">
-                  <strong>
-                    Default configuration is 2 starting + 1 late game traits.
-                  </strong>
-                  Increasing these limits requires corresponding MCM (Mod
-                  Configuration Menu) changes in-game. Make sure your MCM settings
-                  match these limits to avoid conflicts.
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="regular-limit">Starting Traits Limit</Label>
-                  <Input
-                    id="regular-limit"
-                    type="number"
-                    min="0"
-                    max="10"
-                    value={regularLimit}
-                    onChange={e => handleRegularLimitChange(e.target.value)}
-                    className="mt-1"
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Currently selected: {build.traits.regular.length}
-                  </p>
-                </div>
-                <div>
-                  <Label htmlFor="bonus-limit">Late Game Traits Limit</Label>
-                  <Input
-                    id="bonus-limit"
-                    type="number"
-                    min="0"
-                    max="5"
-                    value={bonusLimit}
-                    onChange={e => handleBonusLimitChange(e.target.value)}
-                    className="mt-1"
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Currently selected: {build.traits.bonus.length}
-                  </p>
-                </div>
-              </div>
-
-              {isUsingCustomLimits && (
-                <div className="flex items-start gap-2 p-4 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950">
-                  <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
-                  <div className="text-sm">
-                    <strong>Custom limits detected:</strong> {regularLimit} starting
-                    + {bonusLimit} late game traits. Remember to update your MCM
-                    settings accordingly.
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+          <TraitLimitConfigCard
+            regularLimit={traitLimits.regularLimit}
+            bonusLimit={traitLimits.bonusLimit}
+            onRegularLimitChange={traitLimits.handleRegularLimitChange}
+            onBonusLimitChange={traitLimits.handleBonusLimitChange}
+            currentRegularCount={traitLimits.currentRegularCount}
+            currentBonusCount={traitLimits.currentBonusCount}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/shared/components/generic/ConfigCard.tsx
+++ b/src/shared/components/generic/ConfigCard.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
+import { Input } from '@/shared/ui/ui/input'
+import { Label } from '@/shared/ui/ui/label'
+import { Badge } from '@/shared/ui/ui/badge'
+import { cn } from '@/lib/utils'
+import { 
+  getTraitLimitColor, 
+  getTraitLimitIcon, 
+  getBackgroundColor, 
+  getBorderColor,
+  buildSpacing 
+} from '@/shared/config/buildConfig'
+import { AlertTriangle, Info, Circle, Star } from 'lucide-react'
+
+interface GenericConfigCardProps {
+  title: string
+  description?: string
+  icon?: React.ReactNode
+  variant?: 'default' | 'warning' | 'info' | 'error'
+  children?: React.ReactNode
+  className?: string
+}
+
+interface ConfigInputProps {
+  label: string
+  value: number
+  onChange: (value: number) => void
+  min?: number
+  max?: number
+  currentCount?: number
+  type?: 'regular' | 'bonus'
+  className?: string
+}
+
+interface ConfigAlertProps {
+  type: 'warning' | 'info' | 'error' | 'success'
+  title: string
+  message: string
+  className?: string
+}
+
+// Generic Config Card - follows birthsigns pattern
+export function GenericConfigCard({
+  title,
+  description,
+  icon,
+  variant = 'default',
+  children,
+  className,
+}: GenericConfigCardProps) {
+  const getIcon = () => {
+    if (icon) return icon
+    switch (variant) {
+      case 'warning':
+        return <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
+      case 'info':
+        return <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Card className={cn(buildSpacing.card, className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          {getIcon()}
+          {title}
+        </CardTitle>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </CardHeader>
+      <CardContent className={cn(buildSpacing.section)}>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}
+
+// Config Input Component
+export function ConfigInput({
+  label,
+  value,
+  onChange,
+  min = 0,
+  max = 10,
+  currentCount,
+  type = 'regular',
+  className,
+}: ConfigInputProps) {
+  const getTypeIcon = () => {
+    switch (type) {
+      case 'regular':
+        return <Circle className="h-4 w-4" />
+      case 'bonus':
+        return <Star className="h-4 w-4" />
+      default:
+        return null
+    }
+  }
+
+  const getTypeColor = () => {
+    return getTraitLimitColor(type)
+  }
+
+  return (
+    <div className={cn(buildSpacing.item, className)}>
+      <div className="flex items-center gap-2 mb-2">
+        {getTypeIcon()}
+        <Label htmlFor={`${type}-limit`} className={getTypeColor()}>
+          {label}
+        </Label>
+      </div>
+      <Input
+        id={`${type}-limit`}
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(parseInt(e.target.value) || 0)}
+        className="mt-1"
+      />
+      {currentCount !== undefined && (
+        <p className="text-xs text-muted-foreground mt-1">
+          Currently selected: {currentCount}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// Config Alert Component
+export function ConfigAlert({
+  type,
+  title,
+  message,
+  className,
+}: ConfigAlertProps) {
+  const getIcon = () => {
+    switch (type) {
+      case 'warning':
+        return <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
+      case 'info':
+        return <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+      case 'error':
+        return <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400" />
+      case 'success':
+        return <Info className="h-4 w-4 text-green-600 dark:text-green-400" />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className={cn(
+      'flex items-start gap-2 p-4 rounded-lg border',
+      getBackgroundColor(type),
+      getBorderColor(type),
+      className
+    )}>
+      {getIcon()}
+      <div className="text-sm">
+        <strong>{title}</strong>
+        <p className="mt-1">{message}</p>
+      </div>
+    </div>
+  )
+} 

--- a/src/shared/components/generic/ConfirmDialog.tsx
+++ b/src/shared/components/generic/ConfirmDialog.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { Button } from '@/shared/ui/ui/button'
+import { cn } from '@/lib/utils'
+import { 
+  getConfirmDialogColor, 
+  getConfirmDialogIcon,
+  getBackgroundColor,
+  getBorderColor 
+} from '@/shared/config/buildConfig'
+import { AlertTriangle, Info, XCircle, CheckCircle } from 'lucide-react'
+
+interface GenericConfirmDialogProps {
+  open: boolean
+  title: string
+  message: string
+  variant?: 'warning' | 'info' | 'error' | 'success'
+  confirmText?: string
+  cancelText?: string
+  onConfirm: () => void
+  onCancel: () => void
+  className?: string
+}
+
+export function GenericConfirmDialog({
+  open,
+  title,
+  message,
+  variant = 'warning',
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+  className,
+}: GenericConfirmDialogProps) {
+  if (!open) return null
+
+  const getIcon = () => {
+    switch (variant) {
+      case 'warning':
+        return <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+      case 'info':
+        return <Info className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+      case 'error':
+        return <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+      case 'success':
+        return <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400" />
+      default:
+        return <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+    }
+  }
+
+  const getConfirmVariant = () => {
+    switch (variant) {
+      case 'error':
+        return 'destructive'
+      case 'success':
+        return 'default'
+      default:
+        return 'default'
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className={cn(
+        'bg-white dark:bg-zinc-900 rounded-lg shadow-lg p-6 w-full max-w-xs space-y-4 border',
+        getBorderColor(variant),
+        className
+      )}>
+        <div className="flex items-center gap-2">
+          {getIcon()}
+          <span className="font-semibold">{title}</span>
+        </div>
+        
+        <p className="text-sm text-muted-foreground">
+          {message}
+        </p>
+        
+        <div className="flex justify-end gap-2">
+          <Button 
+            variant="outline" 
+            size="sm" 
+            onClick={onCancel}
+          >
+            {cancelText}
+          </Button>
+          <Button
+            variant={getConfirmVariant()}
+            size="sm"
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/src/shared/components/generic/ShareButton.tsx
+++ b/src/shared/components/generic/ShareButton.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import { Button } from '@/shared/ui/ui/button'
+import { cn } from '@/lib/utils'
+import { 
+  getShareButtonColor, 
+  getShareButtonIcon 
+} from '@/shared/config/buildConfig'
+import { Share2, Check, Link } from 'lucide-react'
+
+interface GenericShareButtonProps {
+  link: string
+  variant?: 'default' | 'outline' | 'ghost'
+  size?: 'sm' | 'lg'
+  icon?: React.ReactNode
+  text?: string
+  onCopied?: () => void
+  className?: string
+}
+
+export function GenericShareButton({
+  link,
+  variant = 'outline',
+  size = 'sm',
+  icon,
+  text = 'Share / Export',
+  onCopied,
+  className,
+}: GenericShareButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(link)
+      setCopied(true)
+      onCopied?.()
+      setTimeout(() => setCopied(false), 1500)
+    } catch (error) {
+      console.error('Failed to copy link:', error)
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea')
+      textArea.value = link
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+      setCopied(true)
+      onCopied?.()
+      setTimeout(() => setCopied(false), 1500)
+    }
+  }
+
+  const getIcon = () => {
+    if (icon) return icon
+    if (copied) {
+      return <Check className="w-4 h-4" />
+    }
+    return <Share2 className="w-4 h-4" />
+  }
+
+  const getText = () => {
+    if (copied) {
+      return 'Copied!'
+    }
+    return text
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant={variant}
+        size={size}
+        onClick={handleCopy}
+        className={cn(
+          'cursor-pointer hover:opacity-90',
+          copied && getShareButtonColor('copied'),
+          className
+        )}
+      >
+        {getIcon()}
+        <span className="ml-2">{getText()}</span>
+      </Button>
+    </div>
+  )
+} 

--- a/src/shared/components/generic/SummaryCard.tsx
+++ b/src/shared/components/generic/SummaryCard.tsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
+import { Badge } from '@/shared/ui/ui/badge'
+import { cn } from '@/lib/utils'
+import { 
+  getSummaryCardColor, 
+  getSummaryCardIcon,
+  buildSpacing 
+} from '@/shared/config/buildConfig'
+import { User, Star, Heart, Tag } from 'lucide-react'
+
+interface SummaryItem {
+  label: string
+  value: string | number
+  icon?: React.ReactNode
+  type?: 'race' | 'birthsign' | 'religion' | 'traits'
+  className?: string
+}
+
+interface GenericSummaryCardProps {
+  title: string
+  items: SummaryItem[]
+  layout?: 'grid' | 'list'
+  className?: string
+}
+
+export function GenericSummaryCard({
+  title,
+  items,
+  layout = 'grid',
+  className,
+}: GenericSummaryCardProps) {
+  const getIcon = (type?: string) => {
+    switch (type) {
+      case 'race':
+        return <User className="h-4 w-4" />
+      case 'birthsign':
+        return <Star className="h-4 w-4" />
+      case 'religion':
+        return <Heart className="h-4 w-4" />
+      case 'traits':
+        return <Tag className="h-4 w-4" />
+      default:
+        return null
+    }
+  }
+
+  const getLayoutClasses = () => {
+    switch (layout) {
+      case 'grid':
+        return 'grid grid-cols-2 md:grid-cols-4 gap-4'
+      case 'list':
+        return 'space-y-3'
+      default:
+        return 'grid grid-cols-2 md:grid-cols-4 gap-4'
+    }
+  }
+
+  return (
+    <Card className={cn(buildSpacing.card, className)}>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className={cn(buildSpacing.section)}>
+        <div className={getLayoutClasses()}>
+          {items.map((item, index) => (
+            <div key={index} className={cn(buildSpacing.item, item.className)}>
+              <div className="flex items-center gap-2 mb-1">
+                {item.icon || getIcon(item.type)}
+                <span className={cn(
+                  'font-medium text-sm',
+                  getSummaryCardColor('primary')
+                )}>
+                  {item.label}:
+                </span>
+              </div>
+              <div className={cn(
+                'text-sm',
+                getSummaryCardColor('secondary')
+              )}>
+                {item.value || 'Not selected'}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Helper function to create summary items from build data
+export function createBuildSummaryItems(build: {
+  race: string | null
+  stone: string | null
+  religion: string | null
+  traits: {
+    regular: string[]
+    bonus: string[]
+  }
+  traitLimits: {
+    regular: number
+    bonus: number
+  }
+}): SummaryItem[] {
+  return [
+    {
+      label: 'Race',
+      value: build.race || 'Not selected',
+      type: 'race',
+    },
+    {
+      label: 'Birth Sign',
+      value: build.stone || 'Not selected',
+      type: 'birthsign',
+    },
+    {
+      label: 'Religion',
+      value: build.religion || 'Not selected',
+      type: 'religion',
+    },
+    {
+      label: 'Traits',
+      value: `${build.traits.regular.length}/${build.traitLimits.regular} starting, ${build.traits.bonus.length}/${build.traitLimits.bonus} late game`,
+      type: 'traits',
+    },
+  ]
+} 

--- a/src/shared/components/generic/index.ts
+++ b/src/shared/components/generic/index.ts
@@ -1,14 +1,27 @@
-// Core generic components
-export {
+// Generic Components
+export { EntityAvatar } from './EntityAvatar'
+export { FormattedText } from './FormattedText'
+export { 
   GenericAccordionCard,
   AccordionLeftControls,
   AccordionHeader,
   AccordionCollapsedContentSlot,
   AccordionExpandedContentSlot,
 } from './GenericAccordionCard'
-export { EntityAvatar } from './EntityAvatar'
 export { CategoryBadge } from './CategoryBadge'
-export { FormattedText } from './FormattedText'
+
+// New Generic Components
+export { 
+  GenericConfigCard, 
+  ConfigInput, 
+  ConfigAlert 
+} from './ConfigCard'
+export { GenericConfirmDialog } from './ConfirmDialog'
+export { GenericShareButton } from './ShareButton'
+export { 
+  GenericSummaryCard, 
+  createBuildSummaryItems 
+} from './SummaryCard'
 
 // Re-export types for convenience
 export type { EntityType, AvatarSize } from './EntityAvatar'

--- a/src/shared/config/buildConfig.ts
+++ b/src/shared/config/buildConfig.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared Configuration System for Build Components
+ * 
+ * This follows the birthsigns pattern of centralized theme configuration
+ * with functions that return theme values for consistency and maintainability.
+ */
+
+// Color mappings for different component types
+export const buildColors = {
+  traitLimit: {
+    regular: 'text-blue-600',
+    bonus: 'text-purple-600',
+    warning: 'text-yellow-600',
+    error: 'text-red-600',
+  },
+  confirmDialog: {
+    destructive: 'text-red-600',
+    safe: 'text-green-600',
+    warning: 'text-yellow-600',
+    info: 'text-blue-600',
+  },
+  shareButton: {
+    copied: 'text-green-600',
+    default: 'text-blue-600',
+    hover: 'text-blue-700',
+  },
+  summaryCard: {
+    primary: 'text-primary',
+    secondary: 'text-muted-foreground',
+    accent: 'text-accent',
+  },
+  backgrounds: {
+    warning: 'bg-yellow-50 dark:bg-yellow-950',
+    info: 'bg-blue-50 dark:bg-blue-950',
+    error: 'bg-red-50 dark:bg-red-950',
+    success: 'bg-green-50 dark:bg-green-950',
+  },
+  borders: {
+    warning: 'border-yellow-200 dark:border-yellow-800',
+    info: 'border-blue-200 dark:border-blue-800',
+    error: 'border-red-200 dark:border-red-800',
+    success: 'border-green-200 dark:border-green-800',
+  },
+}
+
+// Icon mappings for different component types
+export const buildIcons = {
+  traitLimit: {
+    regular: 'Circle',
+    bonus: 'Star',
+    warning: 'AlertTriangle',
+    info: 'Info',
+  },
+  confirmDialog: {
+    warning: 'AlertTriangle',
+    info: 'Info',
+    error: 'XCircle',
+    success: 'CheckCircle',
+  },
+  shareButton: {
+    share: 'Share2',
+    copied: 'Check',
+    link: 'Link',
+  },
+  summaryCard: {
+    race: 'User',
+    birthsign: 'Star',
+    religion: 'Heart',
+    traits: 'Tag',
+  },
+}
+
+// Spacing and layout patterns
+export const buildSpacing = {
+  card: 'p-6 space-y-4',
+  section: 'space-y-3',
+  item: 'space-y-2',
+  inline: 'space-x-2',
+  grid: 'grid grid-cols-1 md:grid-cols-2 gap-4',
+}
+
+// Size mappings for consistent sizing
+export const buildSizes = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+  xl: 'text-xl',
+}
+
+// Configuration functions (following birthsigns pattern)
+export function getTraitLimitColor(type: 'regular' | 'bonus' | 'warning' | 'error') {
+  return buildColors.traitLimit[type]
+}
+
+export function getConfirmDialogColor(type: 'destructive' | 'safe' | 'warning' | 'info') {
+  return buildColors.confirmDialog[type]
+}
+
+export function getShareButtonColor(type: 'copied' | 'default' | 'hover') {
+  return buildColors.shareButton[type]
+}
+
+export function getSummaryCardColor(type: 'primary' | 'secondary' | 'accent') {
+  return buildColors.summaryCard[type]
+}
+
+export function getBackgroundColor(type: 'warning' | 'info' | 'error' | 'success') {
+  return buildColors.backgrounds[type]
+}
+
+export function getBorderColor(type: 'warning' | 'info' | 'error' | 'success') {
+  return buildColors.borders[type]
+}
+
+export function getTraitLimitIcon(type: 'regular' | 'bonus' | 'warning' | 'info') {
+  return buildIcons.traitLimit[type]
+}
+
+export function getConfirmDialogIcon(type: 'warning' | 'info' | 'error' | 'success') {
+  return buildIcons.confirmDialog[type]
+}
+
+export function getShareButtonIcon(type: 'share' | 'copied' | 'link') {
+  return buildIcons.shareButton[type]
+}
+
+export function getSummaryCardIcon(type: 'race' | 'birthsign' | 'religion' | 'traits') {
+  return buildIcons.summaryCard[type]
+} 


### PR DESCRIPTION
…ttern

- Extract generic components to shared/generic/ (ConfigCard, ConfirmDialog, ShareButton, SummaryCard)
- Create feature-specific wrappers in features/build/components/
- Add centralized theme configuration in shared/config/buildConfig.ts
- Create custom hook useTraitLimits for trait limit state management
- Transform BuildPage into pure composition layer with no business logic
- Follow birthsigns pattern of generic + feature-specific wrapper architecture
- Maintain all existing functionality while improving separation of concerns

Components extracted:
- BasicInfoCard: Character name and notes input
- BuildControls: Reset and share button controls
- TraitLimitConfigCard: Trait limit configuration with MCM warnings
- ConfirmDialog: Build-specific confirmation dialogs
- ShareBuildButton: Build link sharing functionality
- BuildSummaryCard: Build summary display

This completes the BuildPage refactor to address separation of concerns and improve maintainability.