### PR TITLE
feat(skills): show minimum skill level badge on skill cards only when…

### DIFF
--- a/docs/skill-levels-implementation.md
+++ b/docs/skill-levels-implementation.md
@@ -1,0 +1,157 @@
+# Skill Levels Implementation
+
+## Overview
+
+The skill levels feature automatically calculates and displays the minimum required skill level based on selected perks. This ensures that when perks are added or removed, the minimum skill level is recalculated to reflect the highest requirement among the remaining perks.
+
+## Implementation Details
+
+### Build State Enhancement
+
+The `BuildState` interface has been extended to include skill levels:
+
+```typescript
+export interface BuildState {
+  // ... existing fields
+  skillLevels: Record<string, number> // skillId -> minimum required level based on selected perks
+}
+```
+
+### Core Utilities
+
+#### `calculateMinimumSkillLevel(skillId, selectedPerks, perkRanks)`
+
+Calculates the minimum skill level required for a specific skill based on its selected perks.
+
+**Parameters:**
+- `skillId`: The skill ID (e.g., 'AVSmithing')
+- `selectedPerks`: Array of selected perk EDIDs for this skill
+- `perkRanks`: Record of perk EDID to current rank
+
+**Returns:** The minimum required skill level, or 0 if no perks require a level
+
+**Logic:**
+1. Returns 0 if no perks are selected
+2. Finds the perk tree for the skill
+3. For each selected perk, checks the skill level requirement at the current rank
+4. Returns the highest required level among all selected perks
+
+#### `calculateAllSkillLevels(perks)`
+
+Calculates minimum skill levels for all skills based on selected perks.
+
+**Parameters:**
+- `perks`: The perks object from build state with `selected` and `ranks` properties
+
+**Returns:** Record of skillId to minimum required level (only includes skills with level requirements > 0)
+
+### Character Build Integration
+
+The `useCharacterBuild` hook has been updated to automatically calculate skill levels whenever perks are modified:
+
+#### Updated Functions:
+- `addPerk()`: Calculates new skill levels after adding a perk
+- `removePerk()`: Recalculates skill levels after removing a perk
+- `setPerkRank()`: Updates skill levels when perk ranks change
+- `clearSkillPerks()`: Resets skill levels when all perks for a skill are cleared
+
+#### New Function:
+- `getSkillLevel(skillId)`: Returns the minimum required level for a specific skill
+
+### UI Integration
+
+#### Skills Page Adapter
+
+The `useSkillsPage` adapter now calculates skill levels for each skill:
+
+```typescript
+const skillLevel = calculateMinimumSkillLevel(
+  skill.id,
+  selectedPerks,
+  build.perks?.ranks || {}
+)
+```
+
+#### Skill Card Display
+
+The `UnifiedSkillCard` component displays skill levels alongside perk counts:
+
+```tsx
+{/* Skill Level and Perks Count */}
+<div className="flex items-center justify-between text-sm text-muted-foreground">
+  {/* Skill Level */}
+  {skill.level > 0 && (
+    <div className="flex items-center gap-1">
+      <span className="text-blue-600 font-medium">Level {skill.level}</span>
+    </div>
+  )}
+  
+  {/* Perks Count */}
+  {skill.totalPerks > 0 && (
+    <div className="flex items-center gap-1">
+      <span>⭐ {skill.selectedPerksCount}/{skill.totalPerks} Perks</span>
+    </div>
+  )}
+</div>
+```
+
+## Data Flow
+
+1. **Perk Selection**: User selects/deselects perks or changes perk ranks
+2. **Build Update**: `useCharacterBuild` functions update the build state
+3. **Level Calculation**: `calculateAllSkillLevels` is called to recalculate all skill levels
+4. **Store Update**: Both perks and skill levels are updated in the character build store
+5. **URL Sync**: The updated build state is encoded and saved to the URL
+6. **UI Update**: Components re-render with the new skill level information
+
+## Example Scenarios
+
+### Scenario 1: Adding a High-Level Perk
+- User selects "Dwarven Smithing" perk (requires Smithing level 25)
+- Skill level for Smithing becomes 25
+- UI displays "Level 25" for the Smithing skill card
+
+### Scenario 2: Adding Multiple Perks
+- User has "Dwarven Smithing" (level 25) and adds "Orcish Smithing" (level 50)
+- Skill level for Smithing becomes 50 (highest requirement)
+- UI displays "Level 50" for the Smithing skill card
+
+### Scenario 3: Removing Perks
+- User removes "Orcish Smithing" (level 50)
+- Skill level for Smithing becomes 25 (remaining highest requirement)
+- UI displays "Level 25" for the Smithing skill card
+
+### Scenario 4: Removing All Perks
+- User removes all perks for Smithing
+- Skill level becomes 0
+- UI no longer displays a level for the Smithing skill card
+
+## Testing
+
+Comprehensive tests are included in `src/features/skills/utils/__tests__/skillLevels.test.ts` covering:
+
+- Empty perk selections
+- Non-existent skill trees
+- Perks without level requirements
+- Single and multiple perk scenarios
+- Rank-based calculations
+- Edge cases and error conditions
+
+## Benefits
+
+1. **Automatic Calculation**: Skill levels are automatically calculated and updated
+2. **Accurate Requirements**: Always shows the correct minimum level needed
+3. **Dynamic Updates**: Changes immediately when perks are modified
+4. **Visual Feedback**: Clear indication of skill requirements in the UI
+5. **Build Validation**: Helps users understand skill prerequisites
+6. **Persistence**: Skill levels are saved with the character build and restored on page refresh
+
+## Future Enhancements
+
+Potential improvements for the skill level system:
+
+1. **Level Validation**: Warn users when they don't meet skill level requirements
+2. **Progressive Display**: Show skill level progression as perks are added
+3. **Requirement Highlighting**: Highlight perks that require higher skill levels
+4. **Build Optimization**: Suggest perk selections that maximize skill level efficiency
+5. **Export Integration**: Include skill levels in character build exports 

--- a/src/features/skills/adapters/useSkillsDetail.ts
+++ b/src/features/skills/adapters/useSkillsDetail.ts
@@ -9,6 +9,7 @@ export interface DetailSkill extends UnifiedSkill {
   isMinor: boolean
   canAssignMajor: boolean
   canAssignMinor: boolean
+  level?: number // Add minimum skill level
 }
 
 // Adapter for skill detail/perk tree views

--- a/src/features/skills/adapters/useSkillsPage.ts
+++ b/src/features/skills/adapters/useSkillsPage.ts
@@ -3,6 +3,7 @@ import { useCharacterBuild } from '@/shared/hooks/useCharacterBuild'
 import { useSkillData } from './useSkillData'
 import { useSkillFilters } from './useSkillFilters'
 import type { UnifiedSkill } from '../types'
+import { calculateMinimumSkillLevel } from '../utils/skillLevels'
 
 export interface SkillsPageSkill extends UnifiedSkill {
   assignmentType: 'major' | 'minor' | 'none'
@@ -50,9 +51,17 @@ export function useSkillsPage() {
       const selectedPerksCount = selectedPerks.length
       const totalPerks = skill.totalPerks ?? 0
       
+      // Calculate minimum skill level based on selected perks
+      const skillLevel = calculateMinimumSkillLevel(
+        skill.id,
+        selectedPerks,
+        build.perks?.ranks || {}
+      )
+      
       return {
         ...skill,
         selectedPerksCount, // Update the selected perks count
+        level: skillLevel, // Update the skill level
         assignmentType: build.skills.major.includes(skill.id)
           ? ('major' as const)
           : build.skills.minor.includes(skill.id)
@@ -63,7 +72,7 @@ export function useSkillsPage() {
         perkCount: `${selectedPerksCount}/${totalPerks}`,
       } as SkillsPageSkill
     })
-  }, [filteredSkills, build.skills.major, build.skills.minor, build.perks?.selected])
+  }, [filteredSkills, build.skills.major, build.skills.minor, build.perks?.selected, build.perks?.ranks])
 
   // Compute skill summary
   const skillSummary = useMemo(() => {

--- a/src/features/skills/components/atomic/SkillItem.tsx
+++ b/src/features/skills/components/atomic/SkillItem.tsx
@@ -5,6 +5,7 @@ import {
   SkillCategoryBadge,
   SkillPerkCountBadge,
 } from './index'
+import { SkillLevelBadge } from './SkillLevelBadge'
 
 // Pure presentational component for individual skill display
 interface SkillItemProps {
@@ -13,6 +14,7 @@ interface SkillItemProps {
   category: string
   assignmentType: 'major' | 'minor' | 'none'
   perkCount: string
+  level?: number
   onSelect: () => void
   onMajorClick: (e: React.MouseEvent) => void
   onMinorClick: (e: React.MouseEvent) => void
@@ -27,6 +29,7 @@ export function SkillItem({
   category,
   assignmentType,
   perkCount,
+  level,
   onSelect,
   onMajorClick,
   onMinorClick,
@@ -62,6 +65,7 @@ export function SkillItem({
       <div className="flex gap-2 flex-wrap mb-4">
         <SkillCategoryBadge category={category} />
         <SkillPerkCountBadge count={perkCount} />
+        {typeof level === 'number' && level > 0 && <SkillLevelBadge level={level} />}
       </div>
 
       {/* Assignment Controls */}

--- a/src/features/skills/components/atomic/SkillLevelBadge.tsx
+++ b/src/features/skills/components/atomic/SkillLevelBadge.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils'
+import { Badge } from '@/shared/ui/ui/badge'
+
+// Pure presentational component for skill level display
+interface SkillLevelBadgeProps {
+  level: number
+  size?: 'sm' | 'md' | 'lg'
+}
+
+export function SkillLevelBadge({ level, size = 'sm' }: SkillLevelBadgeProps) {
+  const sizeClasses = {
+    sm: 'text-xs px-2 py-1',
+    md: 'text-sm px-3 py-1',
+    lg: 'text-base px-4 py-2'
+  }
+  
+  // Only render if level is greater than 0
+  if (level <= 0) {
+    return null
+  }
+  
+  return (
+    <Badge 
+      variant="secondary" 
+      className={cn("bg-blue-100 text-blue-800 border-blue-200", sizeClasses[size])}
+    >
+      Min: Level {level}
+    </Badge>
+  )
+} 

--- a/src/features/skills/components/atomic/__tests__/SkillItem.test.tsx
+++ b/src/features/skills/components/atomic/__tests__/SkillItem.test.tsx
@@ -137,4 +137,6 @@ describe('SkillItem', () => {
 
     expect(screen.queryByText('0/0')).not.toBeInTheDocument()
   })
+
+
 }) 

--- a/src/features/skills/components/atomic/__tests__/SkillLevelBadge.test.tsx
+++ b/src/features/skills/components/atomic/__tests__/SkillLevelBadge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { SkillLevelBadge } from '../SkillLevelBadge'
+
+describe('SkillLevelBadge', () => {
+  it('should render level badge when level is greater than 0', () => {
+    render(<SkillLevelBadge level={25} />)
+    expect(screen.getByText('Min: Level 25')).toBeDefined()
+  })
+
+  it('should not render when level is 0', () => {
+    const { container } = render(<SkillLevelBadge level={0} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should not render when level is negative', () => {
+    const { container } = render(<SkillLevelBadge level={-5} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should apply correct styling classes', () => {
+    render(<SkillLevelBadge level={25} />)
+    const badge = screen.getByText('Min: Level 25')
+    expect(badge.className).toContain('bg-blue-100')
+    expect(badge.className).toContain('text-blue-800')
+  })
+}) 

--- a/src/features/skills/components/atomic/index.ts
+++ b/src/features/skills/components/atomic/index.ts
@@ -3,6 +3,7 @@ export { SkillItem } from './SkillItem'
 export { SkillAssignmentBadge } from './SkillAssignmentBadge'
 export { SkillCategoryBadge } from './SkillCategoryBadge'
 export { SkillPerkCountBadge } from './SkillPerkCountBadge'
+export { SkillLevelBadge } from './SkillLevelBadge'
 export { LoadingView } from './LoadingView'
 export { ErrorView } from './ErrorView'
 

--- a/src/features/skills/components/composition/SkillGrid.tsx
+++ b/src/features/skills/components/composition/SkillGrid.tsx
@@ -10,6 +10,7 @@ interface Skill {
   category: string
   assignmentType: 'major' | 'minor' | 'none'
   perkCount: string
+  level?: number
   canAssignMajor: boolean
   canAssignMinor: boolean
 }
@@ -43,6 +44,7 @@ export function SkillGrid({
           category={skill.category}
           assignmentType={skill.assignmentType}
           perkCount={skill.perkCount}
+          level={skill.level}
           canAssignMajor={skill.canAssignMajor}
           canAssignMinor={skill.canAssignMinor}
           onSelect={() => onSkillSelect(skill.id)}

--- a/src/features/skills/components/composition/UnifiedSkillCard.tsx
+++ b/src/features/skills/components/composition/UnifiedSkillCard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Badge } from '@/shared/ui/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
 import type { DetailSkill } from '../../adapters'
+import { SkillLevelBadge } from '../atomic/SkillLevelBadge'
 
 export interface UnifiedSkillCardProps {
   skill: DetailSkill
@@ -52,12 +53,20 @@ export function UnifiedSkillCard({
       </CardHeader>
 
       <CardContent className="pt-0 space-y-3">
-        {/* Perks Count */}
-        {skill.totalPerks > 0 && (
-          <div className="text-sm text-muted-foreground">
-            ⭐ {skill.selectedPerksCount}/{skill.totalPerks} Perks
-          </div>
-        )}
+        {/* Skill Level and Perks Count */}
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          {/* Skill Level Badge */}
+          {skill.level > 0 && (
+            <SkillLevelBadge level={skill.level} />
+          )}
+          
+          {/* Perks Count */}
+          {skill.totalPerks > 0 && (
+            <div className="flex items-center gap-1">
+              <span>⭐ {skill.selectedPerksCount}/{skill.totalPerks} Perks</span>
+            </div>
+          )}
+        </div>
 
         {/* Assignment Badges */}
         <div className="flex gap-2">

--- a/src/features/skills/components/view/PerkNode.tsx
+++ b/src/features/skills/components/view/PerkNode.tsx
@@ -6,7 +6,7 @@ import {
   HoverCardTrigger,
 } from '@/shared/ui/ui/hover-card'
 import { Z_INDEX } from '@/lib/constants'
-import type { PerkNode as PerkNodeType } from '../types'
+import type { PerkNode as PerkNodeType } from '../../types'
 
 interface PerkNodeProps {
   data: PerkNodeType & {
@@ -136,6 +136,12 @@ const PerkNodeComponent: React.FC<PerkNodeProps> = ({
         <div className="space-y-2">
           <h4 className="font-semibold text-sm">{data.name}</h4>
           <div className="text-sm text-muted-foreground">{description}</div>
+          {/* Minimum skill level requirement */}
+          {typeof data.ranks[0]?.prerequisites?.skillLevel?.level === 'number' && data.ranks[0].prerequisites.skillLevel.level > 0 && (
+            <div className="text-xs text-blue-700 font-medium pt-1">
+              Min. Level: {data.ranks[0].prerequisites.skillLevel.level}
+            </div>
+          )}
           {totalRanks > 1 && (
             <div className="text-xs text-muted-foreground pt-2 border-t">
               <strong>Ranks:</strong> {data.currentRank || 0}/{totalRanks}

--- a/src/features/skills/components/view/SkillPerkTreeDrawer.tsx
+++ b/src/features/skills/components/view/SkillPerkTreeDrawer.tsx
@@ -143,8 +143,13 @@ export function SkillPerkTreeDrawer({
                   <DrawerTitle className="text-xl">
                     {skillName || perkTree.treeName}
                   </DrawerTitle>
-                  <DrawerDescription>
-                    {selectedPerks.length} perks selected
+                  <DrawerDescription className="flex items-center gap-2">
+                    <span>{selectedPerks.length} perks selected</span>
+                    {skills.find(s => s.edid === selectedSkill)?.level && (
+                      <span className="text-blue-600 font-medium">
+                        • Min: Level {skills.find(s => s.edid === selectedSkill)?.level}
+                      </span>
+                    )}
                   </DrawerDescription>
                 </div>
               </div>

--- a/src/features/skills/components/view/SkillsPageView.tsx
+++ b/src/features/skills/components/view/SkillsPageView.tsx
@@ -72,6 +72,7 @@ export function SkillsPageView({
     metaTags: [], // Default value since SkillsPageSkill doesn't have this
     totalPerks: skill.totalPerks,
     selectedPerks: skill.selectedPerksCount,
+    level: skill.level, // Add minimum skill level
     isMajor: skill.assignmentType === 'major',
     isMinor: skill.assignmentType === 'minor',
   }))

--- a/src/features/skills/utils/__tests__/skillLevels.test.ts
+++ b/src/features/skills/utils/__tests__/skillLevels.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest'
+import { calculateMinimumSkillLevel, calculateAllSkillLevels } from '../skillLevels'
+
+// Mock perk trees data for testing
+const mockPerkTreesData = [
+  {
+    treeId: 'AVSmithing',
+    treeName: 'Smithing',
+    treeDescription: 'The art of creating and improving weapons and armor.',
+    category: 'Combat',
+    perks: [
+      {
+        edid: 'REQ_Smithing_Craftsmanship',
+        name: 'Craftsmanship',
+        ranks: [
+          {
+            rank: 1,
+            edid: 'REQ_Smithing_Craftsmanship',
+            name: 'Craftsmanship',
+            description: {
+              base: 'You know how to use tools.',
+              subtext: 'You understand material properties.'
+            },
+            prerequisites: {
+              items: [{ type: 'INGR', id: '0x8C35B997' }]
+            }
+          }
+        ],
+        totalRanks: 1,
+        connections: { parents: [], children: ['REQ_Smithing_DwarvenSmithing'] },
+        isRoot: false,
+        position: { x: 4, y: 2, horizontal: -0.085, vertical: -0.085 }
+      },
+      {
+        edid: 'REQ_Smithing_DwarvenSmithing',
+        name: 'Dwarven Smithing',
+        ranks: [
+          {
+            rank: 1,
+            edid: 'REQ_Smithing_DwarvenSmithing',
+            name: 'Dwarven Smithing',
+            description: {
+              base: 'You can create Dwarven equipment.',
+              subtext: 'You have the secret knowledge.'
+            },
+            prerequisites: {
+              skillLevel: { skill: 'Smithing', level: 25 },
+              items: [{ type: 'INGR', id: '0x8C05CBC7' }]
+            }
+          }
+        ],
+        totalRanks: 1,
+        connections: { parents: ['REQ_Smithing_Craftsmanship'], children: [] },
+        isRoot: false,
+        position: { x: 2, y: 2, horizontal: -0.071, vertical: -0.057 }
+      },
+      {
+        edid: 'REQ_Smithing_OrcishSmithing',
+        name: 'Orcish Smithing',
+        ranks: [
+          {
+            rank: 1,
+            edid: 'REQ_Smithing_OrcishSmithing',
+            name: 'Orcish Smithing',
+            description: {
+              base: 'You can craft Orcish equipment.',
+              subtext: 'You have studied the almanac.'
+            },
+            prerequisites: {
+              skillLevel: { skill: 'Smithing', level: 50 },
+              items: [{ type: 'INGR', id: '0x8C05CBCA' }]
+            }
+          }
+        ],
+        totalRanks: 1,
+        connections: { parents: ['REQ_Smithing_DwarvenSmithing'], children: [] },
+        isRoot: false,
+        position: { x: 2, y: 3, horizontal: -0.042, vertical: -0.071 }
+      }
+    ]
+  }
+]
+
+// Mock the perk trees data import
+vi.mock('../../../public/data/perk-trees.json', () => ({
+  default: mockPerkTreesData
+}))
+
+describe('skillLevels', () => {
+  describe('calculateMinimumSkillLevel', () => {
+    it('should return 0 when no perks are selected', () => {
+      const result = calculateMinimumSkillLevel('AVSmithing', [], {})
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 when skill tree is not found', () => {
+      const result = calculateMinimumSkillLevel('NonExistentSkill', ['some-perk'], {})
+      expect(result).toBe(0)
+    })
+
+    it('should return 0 when selected perk has no skill level requirement', () => {
+      const result = calculateMinimumSkillLevel(
+        'AVSmithing',
+        ['REQ_Smithing_Craftsmanship'],
+        {}
+      )
+      expect(result).toBe(0)
+    })
+
+    it('should return the skill level requirement for a single perk', () => {
+      const result = calculateMinimumSkillLevel(
+        'AVSmithing',
+        ['REQ_Smithing_DwarvenSmithing'],
+        {}
+      )
+      expect(result).toBe(25)
+    })
+
+    it('should return the highest skill level requirement when multiple perks are selected', () => {
+      const result = calculateMinimumSkillLevel(
+        'AVSmithing',
+        ['REQ_Smithing_DwarvenSmithing', 'REQ_Smithing_OrcishSmithing'],
+        {}
+      )
+      expect(result).toBe(50)
+    })
+
+    it('should use the current rank when calculating requirements', () => {
+      const result = calculateMinimumSkillLevel(
+        'AVSmithing',
+        ['REQ_Smithing_DwarvenSmithing'],
+        { 'REQ_Smithing_DwarvenSmithing': 1 }
+      )
+      expect(result).toBe(25)
+    })
+
+    it('should default to rank 1 when rank is not specified', () => {
+      const result = calculateMinimumSkillLevel(
+        'AVSmithing',
+        ['REQ_Smithing_DwarvenSmithing'],
+        {}
+      )
+      expect(result).toBe(25)
+    })
+  })
+
+  describe('calculateAllSkillLevels', () => {
+    it('should return empty object when no perks are selected', () => {
+      const result = calculateAllSkillLevels({ selected: {}, ranks: {} })
+      expect(result).toEqual({})
+    })
+
+    it('should calculate skill levels for multiple skills', () => {
+      const perks = {
+        selected: {
+          'AVSmithing': ['REQ_Smithing_DwarvenSmithing', 'REQ_Smithing_OrcishSmithing'],
+          'AVHeavyArmor': ['REQ_HeavyArmor_Conditioning']
+        },
+        ranks: {}
+      }
+      
+      const result = calculateAllSkillLevels(perks)
+      
+      // Should include AVSmithing with level 50 (highest requirement)
+      expect(result['AVSmithing']).toBe(50)
+      
+      // Should not include AVHeavyArmor since it's not in our mock data
+      expect(result['AVHeavyArmor']).toBeUndefined()
+    })
+
+    it('should handle perks with no skill level requirements', () => {
+      const perks = {
+        selected: {
+          'AVSmithing': ['REQ_Smithing_Craftsmanship']
+        },
+        ranks: {}
+      }
+      
+      const result = calculateAllSkillLevels(perks)
+      
+      // Should not include skills with no level requirements
+      expect(result['AVSmithing']).toBeUndefined()
+    })
+  })
+}) 

--- a/src/features/skills/utils/index.ts
+++ b/src/features/skills/utils/index.ts
@@ -4,4 +4,7 @@ export * from './dataTransform'
 // Export perk-related utilities
 export * from './perkData'
 
+// Export skill level calculation utilities
+export * from './skillLevels'
+
 export { getSkillAssignmentAndPerks } from './skillAssignment'

--- a/src/features/skills/utils/skillLevels.ts
+++ b/src/features/skills/utils/skillLevels.ts
@@ -1,0 +1,120 @@
+import perkTreesData from '../../../../public/data/perk-trees.json'
+
+interface SkillLevelRequirement {
+  skill: string
+  level: number
+}
+
+interface PerkRank {
+  rank: number
+  edid: string
+  name: string
+  description: {
+    base: string
+    subtext: string
+  }
+  prerequisites?: {
+    skillLevel?: SkillLevelRequirement
+    items?: Array<{
+      type: string
+      id: string
+    }>
+  }
+}
+
+interface Perk {
+  edid: string
+  name: string
+  ranks: PerkRank[]
+  totalRanks: number
+  connections: {
+    parents: string[]
+    children: string[]
+  }
+  isRoot: boolean
+  position: {
+    x: number
+    y: number
+    horizontal: number
+    vertical: number
+  }
+}
+
+interface PerkTree {
+  treeId: string
+  treeName: string
+  treeDescription: string
+  category: string
+  perks: Perk[]
+}
+
+/**
+ * Calculate the minimum skill level required for a given skill based on selected perks
+ * @param skillId - The skill ID (e.g., 'AVSmithing')
+ * @param selectedPerks - Array of selected perk EDIDs for this skill
+ * @param perkRanks - Record of perk EDID to current rank
+ * @returns The minimum required skill level, or 0 if no perks require a level
+ */
+export function calculateMinimumSkillLevel(
+  skillId: string,
+  selectedPerks: string[],
+  perkRanks: Record<string, number>
+): number {
+  if (selectedPerks.length === 0) {
+    return 0
+  }
+
+  // Find the perk tree for this skill
+  const perkTree = (perkTreesData as PerkTree[]).find(tree => tree.treeId === skillId)
+  if (!perkTree) {
+    return 0
+  }
+
+  let maxRequiredLevel = 0
+
+  // Check each selected perk
+  for (const perkEdid of selectedPerks) {
+    const perk = perkTree.perks.find(p => p.edid === perkEdid)
+    if (!perk) continue
+
+    // Get the current rank for this perk (default to 1 if not specified)
+    const currentRank = perkRanks[perkEdid] || 1
+
+    // Find the rank data for the current rank
+    const rankData = perk.ranks.find(r => r.rank === currentRank)
+    if (!rankData) continue
+
+    // Check if this rank has a skill level requirement
+    if (rankData.prerequisites?.skillLevel) {
+      const requiredLevel = rankData.prerequisites.skillLevel.level
+      maxRequiredLevel = Math.max(maxRequiredLevel, requiredLevel)
+    }
+  }
+
+  return maxRequiredLevel
+}
+
+/**
+ * Calculate minimum skill levels for all skills based on selected perks
+ * @param perks - The perks object from build state
+ * @returns Record of skillId to minimum required level
+ */
+export function calculateAllSkillLevels(perks: {
+  selected: Record<string, string[]>
+  ranks: Record<string, number>
+}): Record<string, number> {
+  const skillLevels: Record<string, number> = {}
+
+  // Calculate minimum level for each skill that has selected perks
+  for (const [skillId, selectedPerks] of Object.entries(perks.selected)) {
+    if (selectedPerks.length > 0) {
+      const minLevel = calculateMinimumSkillLevel(skillId, selectedPerks, perks.ranks)
+      // Only include skills that actually have level requirements
+      if (minLevel > 0) {
+        skillLevels[skillId] = minLevel
+      }
+    }
+  }
+
+  return skillLevels
+} 

--- a/src/shared/hooks/useCharacterBuild.ts
+++ b/src/shared/hooks/useCharacterBuild.ts
@@ -1,4 +1,5 @@
 import { useCharacterStore } from '@/shared/stores/characterStore'
+import { calculateAllSkillLevels } from '@/features/skills/utils/skillLevels'
 
 export function useCharacterBuild() {
   // Specific selectors for better reactivity
@@ -217,9 +218,16 @@ export function useCharacterBuild() {
           [skillId]: [...skillPerks, perkId],
         },
       }
+      
+      // Calculate new skill levels based on updated perks
+      const newSkillLevels = calculateAllSkillLevels(newPerks)
+      
       console.log('addPerk - updating build with new perks:', newPerks)
+      console.log('addPerk - calculated skill levels:', newSkillLevels)
+      
       updateBuild({
         perks: newPerks,
+        skillLevels: newSkillLevels,
       })
     } else {
       console.log('addPerk - perk already selected, skipping')
@@ -232,14 +240,20 @@ export function useCharacterBuild() {
     
     const newSkillPerks = skillPerks.filter(id => id !== perkId)
     
-    updateBuild({
-      perks: {
-        ...build?.perks,
-        selected: {
-          ...currentPerks,
-          [skillId]: newSkillPerks,
-        },
+    const newPerks = {
+      ...build?.perks,
+      selected: {
+        ...currentPerks,
+        [skillId]: newSkillPerks,
       },
+    }
+    
+    // Calculate new skill levels based on updated perks
+    const newSkillLevels = calculateAllSkillLevels(newPerks)
+    
+    updateBuild({
+      perks: newPerks,
+      skillLevels: newSkillLevels,
     })
   }
 
@@ -247,16 +261,23 @@ export function useCharacterBuild() {
     console.log('setPerkRank called:', { perkId, rank })
     const currentRanks = build?.perks?.ranks ?? {}
     
-    const newRanks = {
+    const newPerks = {
       ...build?.perks,
       ranks: {
         ...currentRanks,
         [perkId]: rank,
       },
     }
-    console.log('setPerkRank - updating build with new ranks:', newRanks)
+    
+    // Calculate new skill levels based on updated perks
+    const newSkillLevels = calculateAllSkillLevels(newPerks)
+    
+    console.log('setPerkRank - updating build with new ranks:', newPerks)
+    console.log('setPerkRank - calculated skill levels:', newSkillLevels)
+    
     updateBuild({
-      perks: newRanks,
+      perks: newPerks,
+      skillLevels: newSkillLevels,
     })
   }
 
@@ -275,12 +296,18 @@ export function useCharacterBuild() {
       })
     }
     
+    const newPerks = {
+      ...build?.perks,
+      selected: remainingPerks,
+      ranks: newRanks,
+    }
+    
+    // Calculate new skill levels based on updated perks
+    const newSkillLevels = calculateAllSkillLevels(newPerks)
+    
     updateBuild({
-      perks: {
-        ...build?.perks,
-        selected: remainingPerks,
-        ranks: newRanks,
-      },
+      perks: newPerks,
+      skillLevels: newSkillLevels,
     })
   }
 
@@ -290,6 +317,10 @@ export function useCharacterBuild() {
 
   const getPerkRank = (perkId: string) => {
     return build?.perks?.ranks?.[perkId] ?? 0
+  }
+
+  const getSkillLevel = (skillId: string) => {
+    return build?.skillLevels?.[skillId] ?? 0
   }
 
   // Clear all selections
@@ -308,6 +339,11 @@ export function useCharacterBuild() {
         regular: [],
         bonus: [],
       },
+      perks: {
+        selected: {},
+        ranks: {},
+      },
+      skillLevels: {},
       destinyPath: [],
     })
   }
@@ -433,6 +469,7 @@ export function useCharacterBuild() {
     clearSkillPerks,
     getSkillPerks,
     getPerkRank,
+    getSkillLevel,
 
     // Trait management
     addTrait,

--- a/src/shared/types/build.ts
+++ b/src/shared/types/build.ts
@@ -21,6 +21,7 @@ export interface BuildState {
     selected: Record<string, string[]> // skillId -> array of perk EDIDs
     ranks: Record<string, number> // perkId -> current rank
   }
+  skillLevels: Record<string, number> // skillId -> minimum required level based on selected perks
   equipment: string[] // Array of EDIDs
   userProgress: {
     unlocks: string[] // Array of unlock IDs
@@ -51,6 +52,7 @@ export const DEFAULT_BUILD: BuildState = {
     selected: {},
     ranks: {},
   },
+  skillLevels: {},
   equipment: [],
   userProgress: {
     unlocks: [],


### PR DESCRIPTION
… > 0 (MVA pattern)\n\n- Add SkillLevelBadge to SkillItem and SkillGrid\n- Fix conditional to avoid showing unformatted 0\n- Ensure badge only appears for skills with a minimum level requirement\n- Follows Model-View-Adapter architecture