### PR TITLE
fix(ui): resolve hydration error in FormattedText component

### DIFF
--- a/src/shared/components/generic/FormattedText.tsx
+++ b/src/shared/components/generic/FormattedText.tsx
@@ -35,15 +35,18 @@ export function FormattedText({
     const lineClampClasses = className.match(/line-clamp-\d+/g) || []
     const otherClasses = className.replace(/line-clamp-\d+/g, '').trim()
 
+    // Use span instead of div when Component is 'p' to avoid invalid HTML
+    const LineClampContainer = Component === 'p' ? 'span' : 'div'
+
     return (
       <Component className={otherClasses}>
-        <div className={`${lineClampClasses.join(' ')} overflow-hidden`}>
+        <LineClampContainer className={`${lineClampClasses.join(' ')} overflow-hidden`}>
           {segments.map(segment => (
             <span key={segment.key} className={segment.className}>
               {segment.text}
             </span>
           ))}
-        </div>
+        </LineClampContainer>
       </Component>
     )
   }


### PR DESCRIPTION
- Fix invalid HTML structure where div was rendered inside p element
- Use span instead of div when component is rendered as p
- Maintains line-clamp functionality while ensuring valid HTML
- Prevents hydration mismatch errors in React