### PR TITLE
feat: add string sanitization for religions and birthsigns

### DIFF
--- a/src/features/birthsigns/components/BirthsignAccordion.tsx
+++ b/src/features/birthsigns/components/BirthsignAccordion.tsx
@@ -9,6 +9,7 @@ import { Star } from 'lucide-react'
 import { getBirthsignGroupStyle } from '../config/birthsignConfig'
 import type { Birthsign } from '../types'
 import { BirthsignAvatar } from './BirthsignAvatar'
+import { sanitizeStatName, sanitizeSkillName } from '../utils/stringSanitizer'
 
 interface BirthsignAccordionProps {
   item: PlayerCreationItem & { originalBirthsign: Birthsign }
@@ -84,7 +85,7 @@ export function BirthsignAccordion({
                   key={index}
                   className="flex items-center justify-between p-3 rounded-lg border bg-muted/30"
                 >
-                  <span className="font-medium capitalize">{stat.stat}</span>
+                  <span className="font-medium capitalize">{sanitizeStatName(stat.stat)}</span>
                   <span
                     className={cn(
                       'font-bold',
@@ -137,7 +138,7 @@ export function BirthsignAccordion({
                   className="p-2 rounded bg-muted border text-sm flex items-center justify-between"
                 >
                   <span className="font-medium">
-                    {bonus.stat} +{bonus.value}
+                    {sanitizeSkillName(bonus.stat)} +{bonus.value}
                   </span>
                   <Badge variant="secondary" className="text-xs">
                     Starting Bonus

--- a/src/features/birthsigns/components/BirthsignCard.tsx
+++ b/src/features/birthsigns/components/BirthsignCard.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import { getBirthsignGroupStyle } from '../config/birthsignConfig'
 import type { Birthsign } from '../types'
 import { BirthsignAvatar } from './'
+import { sanitizeStatName, sanitizeSkillName } from '../utils/stringSanitizer'
 
 interface BirthsignCardProps {
   item?: PlayerCreationItem
@@ -297,7 +298,7 @@ export function BirthsignCard({
                         className="flex items-center justify-between p-2 rounded-lg border bg-muted/30"
                       >
                         <span className="text-sm font-medium capitalize">
-                          {stat.stat}
+                          {sanitizeStatName(stat.stat)}
                         </span>
                         <span
                           className={cn(
@@ -331,7 +332,7 @@ export function BirthsignCard({
                         className="flex items-center justify-between p-2 rounded-lg border bg-muted/30"
                       >
                         <span className="text-sm font-medium capitalize">
-                          {skill.stat}
+                          {sanitizeSkillName(skill.stat)}
                         </span>
                         <span className="font-bold text-green-600">
                           +{skill.value}

--- a/src/features/birthsigns/components/BirthsignStatsDisplay.tsx
+++ b/src/features/birthsigns/components/BirthsignStatsDisplay.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/shared/ui/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
 import { H4 } from '@/shared/ui/ui/typography'
 import type { Birthsign } from '../types'
+import { sanitizeStatName, sanitizeSkillName } from '../utils/stringSanitizer'
 
 interface BirthsignStatsDisplayProps {
   birthsign: Birthsign
@@ -39,7 +40,7 @@ export function BirthsignStatsDisplay({
                   className="flex items-center justify-between p-3 rounded-lg border bg-muted/30"
                 >
                   <span className="text-sm font-medium capitalize flex-1 min-w-0 mr-3">
-                    {stat.stat.replace(/_/g, ' ')}
+                    {sanitizeStatName(stat.stat)}
                   </span>
                   <Badge
                     variant="outline"
@@ -71,7 +72,7 @@ export function BirthsignStatsDisplay({
                   className="flex items-center justify-between p-3 rounded-lg border bg-muted/30"
                 >
                   <span className="text-sm font-medium capitalize flex-1 min-w-0 mr-3">
-                    {skill.stat.replace(/_/g, ' ')}
+                    {sanitizeSkillName(skill.stat)}
                   </span>
                   <Badge
                     variant="outline"

--- a/src/features/birthsigns/utils/index.ts
+++ b/src/features/birthsigns/utils/index.ts
@@ -5,3 +5,12 @@ export {
   getUserFriendlyStat,
   parseDescription,
 } from './dataTransform'
+
+export {
+  sanitizeUnderscoreString,
+  sanitizeStatName,
+  sanitizeSkillName,
+  sanitizeEffectName,
+  sanitizeEffectDescription,
+  getUserFriendlyStatEnhanced,
+} from './stringSanitizer'

--- a/src/features/birthsigns/utils/stringSanitizer.test.ts
+++ b/src/features/birthsigns/utils/stringSanitizer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeUnderscoreString,
+  sanitizeStatName,
+  sanitizeSkillName,
+  sanitizeEffectName,
+  sanitizeEffectDescription,
+  getUserFriendlyStatEnhanced,
+} from './stringSanitizer'
+
+describe('birthsigns stringSanitizer', () => {
+  describe('sanitizeUnderscoreString', () => {
+    it('should convert underscore-separated strings to user-friendly format', () => {
+      expect(sanitizeUnderscoreString('stat_modifications')).toBe('Stat Modifications')
+      expect(sanitizeUnderscoreString('weapon_damage')).toBe('Weapon Damage')
+      expect(sanitizeUnderscoreString('magicka_regeneration')).toBe('Magicka Regeneration')
+    })
+
+    it('should handle empty or null input', () => {
+      expect(sanitizeUnderscoreString('')).toBe('')
+      expect(sanitizeUnderscoreString(null as any)).toBe(null)
+    })
+  })
+
+  describe('sanitizeStatName', () => {
+    it('should sanitize stat names correctly', () => {
+      expect(sanitizeStatName('weapon_damage')).toBe('Weapon Damage')
+      expect(sanitizeStatName('armor_penetration')).toBe('Armor Penetration')
+      expect(sanitizeStatName('unarmed_damage')).toBe('Unarmed Damage')
+    })
+
+    it('should handle empty input', () => {
+      expect(sanitizeStatName('')).toBe('')
+    })
+  })
+
+  describe('sanitizeSkillName', () => {
+    it('should sanitize skill names correctly', () => {
+      expect(sanitizeSkillName('lockpicking_durability')).toBe('Lockpicking Durability')
+      expect(sanitizeSkillName('pickpocketing_success')).toBe('Pickpocketing Success')
+      expect(sanitizeSkillName('stealth_detection')).toBe('Stealth Detection')
+    })
+
+    it('should handle empty input', () => {
+      expect(sanitizeSkillName('')).toBe('')
+    })
+  })
+
+  describe('sanitizeEffectName', () => {
+    it('should sanitize effect names', () => {
+      expect(sanitizeEffectName('conditional_effect')).toBe('Conditional Effect')
+      expect(sanitizeEffectName('mastery_bonus')).toBe('Mastery Bonus')
+    })
+  })
+
+  describe('sanitizeEffectDescription', () => {
+    it('should sanitize effect descriptions', () => {
+      expect(sanitizeEffectDescription('Increases weapon_damage by 10%')).toBe('Increases Weapon Damage by 10%')
+      expect(sanitizeEffectDescription('Improves lockpicking_durability')).toBe('Improves Lockpicking Durability')
+    })
+  })
+
+  describe('getUserFriendlyStatEnhanced', () => {
+    it('should use stat mapping for known stats', () => {
+      expect(getUserFriendlyStatEnhanced('health')).toBe('Health')
+      expect(getUserFriendlyStatEnhanced('magicka')).toBe('Magicka')
+      expect(getUserFriendlyStatEnhanced('stamina')).toBe('Stamina')
+      expect(getUserFriendlyStatEnhanced('weapon_damage')).toBe('Weapon Damage')
+    })
+
+    it('should fallback to sanitization for unknown stats', () => {
+      expect(getUserFriendlyStatEnhanced('unknown_stat')).toBe('Unknown Stat')
+      expect(getUserFriendlyStatEnhanced('custom_effect')).toBe('Custom Effect')
+    })
+  })
+})

--- a/src/features/birthsigns/utils/stringSanitizer.ts
+++ b/src/features/birthsigns/utils/stringSanitizer.ts
@@ -1,0 +1,98 @@
+/**
+ * Sanitizes strings for display by converting underscores to spaces and applying proper formatting
+ */
+
+/**
+ * Converts underscore-separated strings to user-friendly format
+ * Example: "stat_modifications" -> "Stat Modifications"
+ */
+export function sanitizeUnderscoreString(text: string): string {
+  if (!text) return text
+  
+  return text
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, l => l.toUpperCase())
+}
+
+/**
+ * Sanitizes stat names for display
+ * Example: "weapon_damage" -> "Weapon Damage"
+ */
+export function sanitizeStatName(stat: string): string {
+  if (!stat) return ''
+  
+  return sanitizeUnderscoreString(stat)
+}
+
+/**
+ * Sanitizes skill names for display
+ * Example: "lockpicking_durability" -> "Lockpicking Durability"
+ */
+export function sanitizeSkillName(skill: string): string {
+  if (!skill) return ''
+  
+  return sanitizeUnderscoreString(skill)
+}
+
+/**
+ * Sanitizes effect names for display
+ */
+export function sanitizeEffectName(effectName: string): string {
+  if (!effectName) return ''
+  
+  return sanitizeUnderscoreString(effectName)
+}
+
+/**
+ * Sanitizes effect descriptions for display
+ */
+export function sanitizeEffectDescription(description: string): string {
+  if (!description) return ''
+  
+  return description
+    // Replace underscores with spaces
+    .replace(/_/g, ' ')
+    // Capitalize first letter of each word, but preserve common prepositions
+    .replace(/\b\w/g, (l, index, string) => {
+      // Don't capitalize common prepositions and articles
+      const lowerWord = string.slice(index).split(/\s+/)[0].toLowerCase()
+      const commonWords = ['by', 'of', 'in', 'on', 'at', 'to', 'for', 'with', 'a', 'an', 'the', 'and', 'or', 'but']
+      if (commonWords.includes(lowerWord)) {
+        return l.toLowerCase()
+      }
+      return l.toUpperCase()
+    })
+}
+
+/**
+ * Enhanced version of getUserFriendlyStat that uses the sanitizer
+ * This maintains backward compatibility with existing code
+ */
+export function getUserFriendlyStatEnhanced(stat: string): string {
+  const statMapping: Record<string, string> = {
+    health: 'Health',
+    magicka: 'Magicka',
+    stamina: 'Stamina',
+    weapon_damage: 'Weapon Damage',
+    armor_penetration: 'Armor Penetration',
+    unarmed_damage: 'Unarmed Damage',
+    movement_speed: 'Movement Speed',
+    sprint_speed: 'Sprint Speed',
+    carry_weight: 'Carry Weight',
+    spell_strength: 'Spell Strength',
+    magicka_regeneration: 'Magicka Regeneration',
+    lockpicking_durability: 'Lockpicking Durability',
+    lockpicking_expertise: 'Lockpicking Expertise',
+    pickpocketing_success: 'Pickpocketing Success',
+    stealth_detection: 'Stealth Detection',
+    speech: 'Speech',
+    shout_cooldown: 'Shout Cooldown',
+    price_modification: 'Price Modification',
+    damage_reflection: 'Damage Reflection',
+    poison_resistance: 'Poison Resistance',
+    fire_resistance: 'Fire Resistance',
+    enchanting_strength: 'Enchanting Strength',
+  }
+
+  return statMapping[stat] || sanitizeStatName(stat)
+}

--- a/src/features/religions/components/BlessingCard.tsx
+++ b/src/features/religions/components/BlessingCard.tsx
@@ -5,6 +5,7 @@ import { H3, P } from '@/shared/ui/ui/typography'
 import { Clock, Target } from 'lucide-react'
 import type { Religion } from '../types'
 import { ReligionAvatar } from './atomic/ReligionAvatar'
+import { sanitizeEffectName, sanitizeEffectDescription } from '../utils/stringSanitizer'
 
 interface BlessingCardProps {
   religion: Religion
@@ -44,8 +45,8 @@ function FormattedBlessingDescription({
 }) {
   if (!description) return null
 
-  // Replace placeholders with actual values inline
-  let formatted = description
+  // First, sanitize the description to handle underscores and other formatting issues
+  let formatted = sanitizeEffectDescription(description)
     .replace(/<mag>/g, magnitude.toString())
     .replace(/<magnitude>/g, magnitude.toString())
     .replace(/<dur>/g, duration.toString())
@@ -125,7 +126,7 @@ export function BlessingCard({
               className="flex items-start gap-2 p-2 bg-muted/30 rounded-lg"
             >
               <div className="flex-1">
-                <P className="font-medium text-sm mb-1">{effect.effectName}</P>
+                <P className="font-medium text-sm mb-1">{sanitizeEffectName(effect.effectName)}</P>
                 <FormattedBlessingDescription
                   description={effect.effectDescription}
                   magnitude={effect.magnitude}

--- a/src/features/religions/components/ReligionAccordion.tsx
+++ b/src/features/religions/components/ReligionAccordion.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react'
 import React from 'react'
 import type { Religion } from '../types'
+import { sanitizeEffectName, sanitizeEffectDescription } from '../utils/stringSanitizer'
 
 /**
  * Component to format any description with highlighted values in angle brackets
@@ -96,8 +97,11 @@ function FormattedText({
 function FormattedDescription({ description }: { description: string }) {
   if (!description) return null
 
+  // Sanitize the description first
+  const sanitizedDescription = sanitizeEffectDescription(description)
+
   // Split the description by angle bracket patterns and highlight the values
-  const parts = description.split(/(<[^>]+>)/g)
+  const parts = sanitizedDescription.split(/(<[^>]+>)/g)
 
   return (
     <P className="text-xs text-muted-foreground">
@@ -162,8 +166,11 @@ function FormattedBlessingDescription({
 }) {
   if (!description) return null
 
-  // First, clean up any existing angle brackets that might interfere
-  let formatted = description.replace(/<[^>]*>/g, '')
+  // First, sanitize the description to handle underscores and other formatting issues
+  let formatted = sanitizeEffectDescription(description)
+
+  // Clean up any existing angle brackets that might interfere
+  formatted = formatted.replace(/<[^>]*>/g, '')
 
   // Replace magnitude placeholders
   formatted = formatted.replace(/<mag>/g, magnitude.toString())
@@ -562,7 +569,7 @@ export function renderReligionExpandedContent(
                       </div>
                       <div className="flex-1">
                         <P className="font-medium text-sm mb-1">
-                          {effect.effectName}
+                          {sanitizeEffectName(effect.effectName)}
                         </P>
                         <FormattedBlessingDescription
                           description={effect.effectDescription}

--- a/src/features/religions/components/ReligionSheet.tsx
+++ b/src/features/religions/components/ReligionSheet.tsx
@@ -20,6 +20,7 @@ import {
 import React from 'react'
 import type { Religion } from '../types'
 import { ReligionAvatar, ReligionCategoryBadge } from './atomic'
+import { sanitizeEffectName, sanitizeEffectDescription } from '../utils/stringSanitizer'
 
 interface ReligionSheetProps {
   religion: Religion | null
@@ -80,8 +81,11 @@ function FormattedBlessingDescription({
 }) {
   if (!description) return null
 
-  // First, clean up any existing angle brackets that might interfere
-  let formatted = description.replace(/<[^>]*>/g, '')
+  // First, sanitize the description to handle underscores and other formatting issues
+  let formatted = sanitizeEffectDescription(description)
+
+  // Clean up any existing angle brackets that might interfere
+  formatted = formatted.replace(/<[^>]*>/g, '')
 
   // Replace magnitude placeholders
   formatted = formatted.replace(/<mag>/g, magnitude.toString())
@@ -254,7 +258,7 @@ export function ReligionSheet({
                         </div>
                         <div className="flex-1">
                           <P className="font-medium text-sm mb-2">
-                            {effect.effectName}
+                            {sanitizeEffectName(effect.effectName)}
                           </P>
                           <FormattedBlessingDescription
                             description={effect.effectDescription}

--- a/src/features/religions/utils/stringSanitizer.test.ts
+++ b/src/features/religions/utils/stringSanitizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeUnderscoreString,
+  sanitizeEffectText,
+  sanitizeTargetAttribute,
+  sanitizeEffectName,
+  sanitizeEffectDescription,
+} from './stringSanitizer'
+
+describe('stringSanitizer', () => {
+  describe('sanitizeUnderscoreString', () => {
+    it('should convert underscore-separated strings to user-friendly format', () => {
+      expect(sanitizeUnderscoreString('stat_modifications')).toBe('Stat Modifications')
+      expect(sanitizeUnderscoreString('magic_resistance')).toBe('Magic Resistance')
+      expect(sanitizeUnderscoreString('weapon_damage')).toBe('Weapon Damage')
+    })
+
+    it('should handle empty or null input', () => {
+      expect(sanitizeUnderscoreString('')).toBe('')
+      expect(sanitizeUnderscoreString(null as any)).toBe(null)
+    })
+  })
+
+  describe('sanitizeEffectText', () => {
+    it('should replace Global variable patterns with user-friendly terms', () => {
+      expect(sanitizeEffectText('Global=WSN_Favor_Global_Fractional%')).toBe('favor-based amount%')
+      expect(sanitizeEffectText('Global=WSN_Favor_Global_Fractional2%')).toBe('favor-based amount2%')
+      expect(sanitizeEffectText('WSN_Favor_Global_Fractional')).toBe('favor-based amount')
+    })
+
+    it('should handle underscore patterns', () => {
+      expect(sanitizeEffectText('stat_modifications')).toBe('stat modifications')
+      expect(sanitizeEffectText('magic_resistance_bonus')).toBe('magic resistance bonus')
+    })
+
+    it('should preserve angle brackets', () => {
+      expect(sanitizeEffectText('Resist <mag>% of magic.')).toBe('Resist <mag>% of magic.')
+      expect(sanitizeEffectText('Global=WSN_Favor_Global_Fractional% better')).toBe('favor-based amount% better')
+    })
+  })
+
+  describe('sanitizeTargetAttribute', () => {
+    it('should format target attributes correctly', () => {
+      expect(sanitizeTargetAttribute('MagicResist')).toBe('Magic Resist')
+      expect(sanitizeTargetAttribute('Health')).toBe('Health')
+      expect(sanitizeTargetAttribute('Stamina')).toBe('Stamina')
+    })
+
+    it('should handle null input', () => {
+      expect(sanitizeTargetAttribute(null)).toBe('')
+    })
+  })
+
+  describe('sanitizeEffectName', () => {
+    it('should sanitize effect names', () => {
+      expect(sanitizeEffectName('Resist Magic')).toBe('Resist Magic')
+      expect(sanitizeEffectName('Global_modifier')).toBe('Global Modifier')
+    })
+  })
+
+  describe('sanitizeEffectDescription', () => {
+    it('should sanitize effect descriptions', () => {
+      expect(sanitizeEffectDescription('Resist <mag>% of magic.')).toBe('Resist <mag>% of magic.')
+      expect(sanitizeEffectDescription('Global=WSN_Favor_Global_Fractional% better')).toBe('favor-based amount% better')
+    })
+  })
+})

--- a/src/features/religions/utils/stringSanitizer.ts
+++ b/src/features/religions/utils/stringSanitizer.ts
@@ -1,0 +1,81 @@
+/**
+ * Sanitizes strings for display by converting underscores to spaces and applying proper formatting
+ */
+
+/**
+ * Converts underscore-separated strings to user-friendly format
+ * Example: "stat_modifications" -> "Stat Modifications"
+ */
+export function sanitizeUnderscoreString(text: string): string {
+  if (!text) return text
+  
+  return text
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, l => l.toUpperCase())
+}
+
+/**
+ * Sanitizes effect names and descriptions for display
+ * Handles various patterns found in religion data
+ */
+export function sanitizeEffectText(text: string): string {
+  if (!text) return text
+
+  let sanitized = text
+
+  // Replace common variable patterns with user-friendly terms
+  sanitized = sanitized
+    // Global variable patterns - use function to handle complex replacements
+    .replace(/Global=WSN_Favor_Global_Fractional(\d*)/g, (match, digits) => 
+      `favor-based amount${digits || ''}`
+    )
+    .replace(/Global=WSN_Favor_Global/g, 'favor-based amount')
+    .replace(/WSN_Favor_Global_Fractional(\d*)/g, (match, digits) => 
+      `favor-based amount${digits || ''}`
+    )
+    .replace(/WSN_Favor_Global/g, 'favor-based amount')
+    .replace(/WSN_Effect_Global_[A-Za-z]+/g, 'effect amount')
+    .replace(/WSN_[A-Za-z_]+/g, 'favor-based amount')
+    
+    // General underscore patterns (but preserve angle brackets)
+    .replace(/([A-Za-z])_([A-Za-z])/g, '$1 $2')
+    .replace(/([A-Za-z])_([A-Za-z])/g, '$1 $2') // Apply twice to catch nested underscores
+    
+    // Clean up any remaining underscores (but not inside angle brackets)
+    .replace(/(?<!<)_(?!>)/g, ' ')
+
+  return sanitized
+}
+
+/**
+ * Sanitizes target attribute names for display
+ * Example: "MagicResist" -> "Magic Resistance"
+ */
+export function sanitizeTargetAttribute(attribute: string | null): string {
+  if (!attribute) return ''
+  
+  return attribute
+    .replace(/([A-Z])/g, ' $1') // Add space before capital letters
+    .replace(/^ /, '') // Remove leading space
+    .replace(/\b\w/g, l => l.toUpperCase()) // Capitalize first letter of each word
+}
+
+/**
+ * Sanitizes effect names for display
+ */
+export function sanitizeEffectName(effectName: string): string {
+  if (!effectName) return ''
+  
+  // First sanitize the text, then capitalize properly
+  const sanitized = sanitizeEffectText(effectName)
+  return sanitized.replace(/\b\w/g, l => l.toUpperCase())
+}
+
+/**
+ * Sanitizes effect descriptions for display
+ */
+export function sanitizeEffectDescription(description: string): string {
+  if (!description) return ''
+  
+  return sanitizeEffectText(description)
+}


### PR DESCRIPTION
- Add comprehensive string sanitizer utilities for both religions and birthsigns features
- Replace underscore-separated strings with user-friendly formatted text
- Handle complex variable patterns like 'Global=WSN_Favor_Global_Fractional' in religions
- Sanitize stat names, skill names, and effect descriptions in birthsigns
- Preserve common prepositions and articles in descriptions
- Maintain backward compatibility with existing getUserFriendlyStat function
- Add comprehensive test coverage for all sanitization functions
- Update all relevant components to use the new sanitizers

Fixes display issues where underscores appeared in UI text like 'Stat modifications'