### PR TITLE
feat: add religion bullet points to Discord export format

### DIFF
--- a/src/shared/services/__tests__/buildExportService.test.ts
+++ b/src/shared/services/__tests__/buildExportService.test.ts
@@ -1,6 +1,52 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { hydrateBuildData } from '../buildExportService'
 import type { BuildState } from '@/shared/types/build'
+
+// Mock the religions store
+vi.mock('@/shared/stores/religionsStore', () => ({
+  useReligionsStore: {
+    getState: vi.fn(() => ({
+      data: [
+        {
+          id: 'Akatosh',
+          name: 'Akatosh',
+          type: 'Divine',
+          pantheon: 'Divine',
+          tenet: {
+            description: 'Fulfill your destiny by saving Tamriel. Raise your character level. Absorb dragon souls.',
+            effects: [
+              {
+                effectDescription: 'Fulfill your destiny by saving Tamriel. Raise your character level. Absorb dragon souls.'
+              }
+            ]
+          },
+          boon1: {
+            spellName: 'Father of Dragons',
+            effects: [
+              {
+                effectDescription: 'Attacks, spells, scrolls, shouts and enchantments are better against dragons.'
+              }
+            ]
+          },
+          boon2: {
+            spellName: 'Turn the Hourglass',
+            effects: [
+              {
+                effectDescription: 'Praying to Akatosh resets the cooldown of your most recently used shout and power.'
+              }
+            ]
+          }
+        },
+        {
+          id: 'Mara',
+          name: 'Mara',
+          type: 'Divine',
+          pantheon: 'Divine',
+        },
+      ],
+    })),
+  },
+}))
 
 describe('buildExportService', () => {
   describe('hydrateBuildData', () => {
@@ -106,6 +152,147 @@ describe('buildExportService', () => {
       expect(hydratedData.attributes.stamina).toBe(0)
       expect(hydratedData.attributes.magicka).toBe(0)
       expect(hydratedData.attributes.totalPoints).toBe(0)
+    })
+
+    it('should resolve religion by lowercase hyphenated ID', () => {
+      const mockBuild: BuildState = {
+        v: 1,
+        name: 'Test Character',
+        notes: '',
+        race: null,
+        stone: null,
+        religion: 'akatosh', // This is the format stored when a religion is selected
+        traits: {
+          regular: [],
+          bonus: [],
+        },
+        traitLimits: {
+          regular: 2,
+          bonus: 1,
+        },
+        skills: {
+          major: [],
+          minor: [],
+        },
+        perks: {
+          selected: {},
+          ranks: {},
+        },
+        skillLevels: {},
+        equipment: [],
+        userProgress: {
+          unlocks: [],
+        },
+        destinyPath: [],
+        attributeAssignments: {
+          health: 0,
+          stamina: 0,
+          magicka: 0,
+          level: 1,
+          assignments: {},
+        },
+      }
+
+      const hydratedData = hydrateBuildData(mockBuild)
+
+      expect(hydratedData.religion.name).toBe('Akatosh')
+      expect(hydratedData.religion.effects).toBe('Divine')
+      expect(hydratedData.religion.tenets).toBe('Fulfill your destiny by saving Tamriel. Raise your character level. Absorb dragon souls.')
+      expect(hydratedData.religion.followerBoon).toBe('Attacks, spells, scrolls, shouts and enchantments are better against dragons.')
+      expect(hydratedData.religion.devoteeBoon).toBe('Praying to Akatosh resets the cooldown of your most recently used shout and power.')
+    })
+
+    it('should resolve religion by original ID', () => {
+      const mockBuild: BuildState = {
+        v: 1,
+        name: 'Test Character',
+        notes: '',
+        race: null,
+        stone: null,
+        religion: 'Akatosh', // This is the original ID format
+        traits: {
+          regular: [],
+          bonus: [],
+        },
+        traitLimits: {
+          regular: 2,
+          bonus: 1,
+        },
+        skills: {
+          major: [],
+          minor: [],
+        },
+        perks: {
+          selected: {},
+          ranks: {},
+        },
+        skillLevels: {},
+        equipment: [],
+        userProgress: {
+          unlocks: [],
+        },
+        destinyPath: [],
+        attributeAssignments: {
+          health: 0,
+          stamina: 0,
+          magicka: 0,
+          level: 1,
+          assignments: {},
+        },
+      }
+
+      const hydratedData = hydrateBuildData(mockBuild)
+
+      expect(hydratedData.religion.name).toBe('Akatosh')
+      expect(hydratedData.religion.effects).toBe('Divine')
+      expect(hydratedData.religion.tenets).toBe('Fulfill your destiny by saving Tamriel. Raise your character level. Absorb dragon souls.')
+      expect(hydratedData.religion.followerBoon).toBe('Attacks, spells, scrolls, shouts and enchantments are better against dragons.')
+      expect(hydratedData.religion.devoteeBoon).toBe('Praying to Akatosh resets the cooldown of your most recently used shout and power.')
+    })
+
+    it('should handle unknown religion gracefully', () => {
+      const mockBuild: BuildState = {
+        v: 1,
+        name: 'Test Character',
+        notes: '',
+        race: null,
+        stone: null,
+        religion: 'unknown-religion',
+        traits: {
+          regular: [],
+          bonus: [],
+        },
+        traitLimits: {
+          regular: 2,
+          bonus: 1,
+        },
+        skills: {
+          major: [],
+          minor: [],
+        },
+        perks: {
+          selected: {},
+          ranks: {},
+        },
+        skillLevels: {},
+        equipment: [],
+        userProgress: {
+          unlocks: [],
+        },
+        destinyPath: [],
+        attributeAssignments: {
+          health: 0,
+          stamina: 0,
+          magicka: 0,
+          level: 1,
+          assignments: {},
+        },
+      }
+
+      const hydratedData = hydrateBuildData(mockBuild)
+
+      expect(hydratedData.religion.name).toBe('Unknown Religion')
+      expect(hydratedData.religion.effects).toBe('No effects')
     })
   })
 }) 

--- a/src/shared/services/buildExportService.ts
+++ b/src/shared/services/buildExportService.ts
@@ -186,6 +186,9 @@ function resolveTraits(
 function resolveReligion(religionId: string | null): {
   name: string
   effects: string
+  tenets?: string
+  followerBoon?: string
+  devoteeBoon?: string
 } {
   if (!religionId) return { name: 'Not selected', effects: 'No effects' }
 
@@ -200,15 +203,38 @@ function resolveReligion(religionId: string | null): {
         )
       }
 
+      // Try to find religion using the same logic as findReligionById
+      // This handles the ID format mismatch between selection and storage
       const religion = religions.find(
-        r => r.id === religionId || r.name === religionId
+        r => 
+          r.id === religionId || 
+          r.name === religionId ||
+          r.name.toLowerCase().replace(/\s+/g, '-') === religionId
       )
 
       if (!religion) return { name: 'Unknown Religion', effects: 'No effects' }
 
+      // Extract tenets from the first tenet effect description
+      const tenets = religion.tenet?.effects?.[0]?.effectDescription || 
+                    religion.tenet?.description || 
+                    undefined
+
+      // Extract follower boon (boon1) from the first effect description
+      const followerBoon = religion.boon1?.effects?.[0]?.effectDescription || 
+                          religion.boon1?.spellName || 
+                          undefined
+
+      // Extract devotee boon (boon2) from the first effect description
+      const devoteeBoon = religion.boon2?.effects?.[0]?.effectDescription || 
+                         religion.boon2?.spellName || 
+                         undefined
+
       return {
         name: religion.name,
         effects: formatForDiscord(religion.type || 'No effects'),
+        tenets: tenets ? formatForDiscord(tenets) : undefined,
+        followerBoon: followerBoon ? formatForDiscord(followerBoon) : undefined,
+        devoteeBoon: devoteeBoon ? formatForDiscord(devoteeBoon) : undefined,
       }
     },
     { name: 'Unknown Religion', effects: 'No effects' },

--- a/src/shared/stores/religionsStore.ts
+++ b/src/shared/stores/religionsStore.ts
@@ -75,7 +75,11 @@ export const useReligionsStore = create<ReligionsStore>((set, get) => ({
   // Computed
   getById: (id: string) => {
     const state = get()
-    return state.data.find(religion => religion.id === id)
+    return state.data.find(religion => 
+      religion.id === id || 
+      religion.name === id ||
+      religion.name.toLowerCase().replace(/\s+/g, '-') === id
+    )
   },
 
   search: (query: string) => {

--- a/src/shared/types/discordExport.ts
+++ b/src/shared/types/discordExport.ts
@@ -4,7 +4,13 @@ export interface HydratedBuildData {
   race: { name: string; effects?: string }
   birthSign: { name: string; effects: string }
   traits: Array<{ name: string; effects: string; type: 'regular' | 'bonus' }>
-  religion: { name: string; effects: string }
+  religion: { 
+    name: string; 
+    effects: string;
+    tenets?: string;
+    followerBoon?: string;
+    devoteeBoon?: string;
+  }
   skills: {
     major: Array<{ name: string; level?: number }>
     minor: Array<{ name: string; level?: number }>

--- a/src/shared/utils/__tests__/discordExportFormatter.test.ts
+++ b/src/shared/utils/__tests__/discordExportFormatter.test.ts
@@ -3,88 +3,115 @@ import { formatBuildForDiscordNamesOnly, formatBuildForDiscord } from '../discor
 import type { HydratedBuildData } from '@/shared/types/discordExport'
 
 describe('discordExportFormatter', () => {
-  const mockHydratedData: HydratedBuildData = {
-    name: 'Test Character',
-    notes: 'Test notes',
-    race: { name: 'Nord' },
-    birthSign: { name: 'The Warrior', effects: 'Combat bonuses' },
-    traits: [
-      { name: 'Warrior Born', effects: 'Combat skill bonuses', type: 'regular' }
-    ],
-    religion: { name: 'Talos', effects: 'Divine blessings' },
-    skills: {
-      major: [{ name: 'One-Handed', level: 50 }],
-      minor: [{ name: 'Heavy Armor' }],
-      other: []
-    },
-    perks: [
-      {
-        skillName: 'One-Handed',
-        perks: [{ name: 'Armsman', effects: 'Increased damage', rank: 2 }]
-      }
-    ],
-    destinyPath: [{ name: 'Warrior Path', effects: 'Combat mastery' }],
-    tags: ['lorerim', 'nord', 'warrior'],
-    attributes: {
-      level: 7,
-      health: 3,
-      stamina: 2,
-      magicka: 1,
-      totalPoints: 6
-    }
-  }
-
   describe('formatBuildForDiscordNamesOnly', () => {
     it('should include attributes section in names-only format', () => {
-      const formatted = formatBuildForDiscordNamesOnly(mockHydratedData)
-      
-      expect(formatted).toContain('__⚔️ Attributes (Level 7)__')
-      expect(formatted).toContain('Health: 3, Stamina: 2, Magicka: 1')
+      const mockData: HydratedBuildData = {
+        name: 'Test Character',
+        notes: '',
+        race: { name: 'Nord', effects: 'Test effects' },
+        birthSign: { name: 'Warrior', effects: 'Test effects' },
+        traits: [],
+        religion: { name: 'Akatosh', effects: 'Divine' },
+        skills: { major: [], minor: [], other: [] },
+        perks: [],
+        destinyPath: [],
+        tags: [],
+        attributes: {
+          level: 5,
+          health: 15,
+          stamina: 10,
+          magicka: 5,
+          totalPoints: 30,
+        },
+      }
+
+      const result = formatBuildForDiscordNamesOnly(mockData)
+
+      expect(result).toContain('__⚔️ Attributes (Level 5)__')
+      expect(result).toContain('Health: 15, Stamina: 10, Magicka: 5')
     })
 
     it('should handle builds with no attribute points', () => {
-      const dataWithNoAttributes = {
-        ...mockHydratedData,
+      const mockData: HydratedBuildData = {
+        name: 'Test Character',
+        notes: '',
+        race: { name: 'Nord', effects: 'Test effects' },
+        birthSign: { name: 'Warrior', effects: 'Test effects' },
+        traits: [],
+        religion: { name: 'Akatosh', effects: 'Divine' },
+        skills: { major: [], minor: [], other: [] },
+        perks: [],
+        destinyPath: [],
+        tags: [],
         attributes: {
           level: 1,
           health: 0,
           stamina: 0,
           magicka: 0,
-          totalPoints: 0
-        }
+          totalPoints: 0,
+        },
       }
-      
-      const formatted = formatBuildForDiscordNamesOnly(dataWithNoAttributes)
-      
-      expect(formatted).toContain('__⚔️ Attributes (Level 1)__')
-      expect(formatted).toContain('No attribute points assigned')
+
+      const result = formatBuildForDiscordNamesOnly(mockData)
+
+      expect(result).toContain('__⚔️ Attributes (Level 1)__')
+      expect(result).toContain('No attribute points assigned')
     })
   })
 
   describe('formatBuildForDiscord', () => {
     it('should include attributes section in full format', () => {
-      const formatted = formatBuildForDiscord(mockHydratedData)
-      
-      expect(formatted).toContain('__⚔️ Attributes (Level 7)__')
-      expect(formatted).toContain('Health: 3, Stamina: 2, Magicka: 1')
+      const mockData: HydratedBuildData = {
+        name: 'Test Character',
+        notes: '',
+        race: { name: 'Nord', effects: 'Test effects' },
+        birthSign: { name: 'Warrior', effects: 'Test effects' },
+        traits: [],
+        religion: { name: 'Akatosh', effects: 'Divine' },
+        skills: { major: [], minor: [], other: [] },
+        perks: [],
+        destinyPath: [],
+        tags: [],
+        attributes: {
+          level: 5,
+          health: 15,
+          stamina: 10,
+          magicka: 5,
+          totalPoints: 30,
+        },
+      }
+
+      const result = formatBuildForDiscord(mockData)
+
+      expect(result).toContain('__⚔️ Attributes (Level 5)__')
+      expect(result).toContain('Health: 15, Stamina: 10, Magicka: 5')
     })
 
     it('should handle builds with no attribute points', () => {
-      const dataWithNoAttributes = {
-        ...mockHydratedData,
+      const mockData: HydratedBuildData = {
+        name: 'Test Character',
+        notes: '',
+        race: { name: 'Nord', effects: 'Test effects' },
+        birthSign: { name: 'Warrior', effects: 'Test effects' },
+        traits: [],
+        religion: { name: 'Akatosh', effects: 'Divine' },
+        skills: { major: [], minor: [], other: [] },
+        perks: [],
+        destinyPath: [],
+        tags: [],
         attributes: {
           level: 1,
           health: 0,
           stamina: 0,
           magicka: 0,
-          totalPoints: 0
-        }
+          totalPoints: 0,
+        },
       }
-      
-      const formatted = formatBuildForDiscord(dataWithNoAttributes)
-      
-      expect(formatted).toContain('__⚔️ Attributes (Level 1)__')
-      expect(formatted).toContain('No attribute points assigned')
+
+      const result = formatBuildForDiscord(mockData)
+
+      expect(result).toContain('__⚔️ Attributes (Level 1)__')
+      expect(result).toContain('No attribute points assigned')
     })
   })
 }) 

--- a/src/shared/utils/discordExportFormatter.ts
+++ b/src/shared/utils/discordExportFormatter.ts
@@ -46,6 +46,15 @@ export function formatBuildForDiscordNamesOnly(
   // Religion
   lines.push(`__✝️ Religion__`)
   lines.push(`${data.religion.name}`)
+  if (data.religion.tenets) {
+    lines.push(`• **Tenets:** ${data.religion.tenets}`)
+  }
+  if (data.religion.followerBoon) {
+    lines.push(`• **Follower:** ${data.religion.followerBoon}`)
+  }
+  if (data.religion.devoteeBoon) {
+    lines.push(`• **Devotee:** ${data.religion.devoteeBoon}`)
+  }
   lines.push('')
 
   // NEW: Attributes
@@ -170,6 +179,15 @@ export function formatBuildForDiscord(
   // Religion
   lines.push(`__✝️ Religion__`)
   lines.push(`${data.religion.name}`)
+  if (data.religion.tenets) {
+    lines.push(`• **Tenets:** ${data.religion.tenets}`)
+  }
+  if (data.religion.followerBoon) {
+    lines.push(`• **Follower:** ${data.religion.followerBoon}`)
+  }
+  if (data.religion.devoteeBoon) {
+    lines.push(`• **Devotee:** ${data.religion.devoteeBoon}`)
+  }
   lines.push('')
 
   // NEW: Attributes


### PR DESCRIPTION
- Add tenets, follower boon, and devotee boon to religion export

- Update HydratedBuildData interface to include new religion fields

- Enhance resolveReligion function to extract detailed religion data

- Update Discord export formatter to display religion bullet points

- Add comprehensive tests for new religion export functionality

- Fix religion ID format mismatch between selection and export