### PR TITLE
feat: add favorite blessing persistence and export functionality

### DIFF
--- a/src/shared/hooks/useURLSync.ts
+++ b/src/shared/hooks/useURLSync.ts
@@ -64,6 +64,7 @@ export const useURLSync = () => {
     build.race, 
     build.stone, 
     build.religion, 
+    build.favoriteBlessing,
     build.traits, 
     build.traitLimits,
     build.skills, 

--- a/src/shared/services/__tests__/buildExportService.test.ts
+++ b/src/shared/services/__tests__/buildExportService.test.ts
@@ -48,6 +48,80 @@ vi.mock('@/shared/stores/religionsStore', () => ({
   },
 }))
 
+// Mock the blessings store
+vi.mock('@/shared/stores/blessingsStore', () => ({
+  useBlessingsStore: {
+    getState: vi.fn(() => ({
+      data: [
+        {
+          id: 'Akatosh',
+          name: 'Akatosh',
+          type: 'Divine',
+          pantheon: 'Divine',
+          blessingName: 'Blessing of Akatosh',
+          blessingDescription: 'Divine blessing from Akatosh',
+          effects: [
+            {
+              name: 'Dragon Slayer',
+              description: 'Attacks, spells, scrolls, shouts and enchantments are better against dragons.',
+              magnitude: 25,
+              duration: 300,
+              area: 0,
+              effectType: '2',
+              targetAttribute: null,
+              keywords: ['dragon', 'combat']
+            },
+            {
+              name: 'Time Reset',
+              description: 'Praying to Akatosh resets the cooldown of your most recently used shout and power.',
+              magnitude: 1,
+              duration: 0,
+              area: 0,
+              effectType: '2',
+              targetAttribute: null,
+              keywords: ['prayer', 'cooldown']
+            }
+          ],
+          tags: ['Divine', 'Dragonborn'],
+          originalReligion: {
+            id: 'Akatosh',
+            name: 'Akatosh',
+            type: 'Divine',
+            pantheon: 'Divine',
+          }
+        },
+        {
+          id: 'Mara',
+          name: 'Mara',
+          type: 'Divine',
+          pantheon: 'Divine',
+          blessingName: 'Blessing of Mara',
+          blessingDescription: 'Divine blessing from Mara',
+          effects: [
+            {
+              name: 'Lover\'s Comfort',
+              description: 'Restore health and stamina.',
+              magnitude: 50,
+              duration: 600,
+              area: 0,
+              effectType: '2',
+              targetAttribute: 'health',
+              keywords: ['healing', 'restoration']
+            }
+          ],
+          tags: ['Divine', 'Healing'],
+          originalReligion: {
+            id: 'Mara',
+            name: 'Mara',
+            type: 'Divine',
+            pantheon: 'Divine',
+          }
+        },
+      ],
+    })),
+  },
+}))
+
 describe('buildExportService', () => {
   describe('hydrateBuildData', () => {
     it('should include attribute assignments in hydrated data', () => {
@@ -58,6 +132,7 @@ describe('buildExportService', () => {
         race: null,
         stone: null,
         religion: null,
+        favoriteBlessing: null,
         traits: {
           regular: [],
           bonus: [],
@@ -114,6 +189,7 @@ describe('buildExportService', () => {
         race: null,
         stone: null,
         religion: null,
+        favoriteBlessing: null,
         traits: {
           regular: [],
           bonus: [],
@@ -162,6 +238,7 @@ describe('buildExportService', () => {
         race: null,
         stone: null,
         religion: 'akatosh', // This is the format stored when a religion is selected
+        favoriteBlessing: null,
         traits: {
           regular: [],
           bonus: [],
@@ -210,6 +287,7 @@ describe('buildExportService', () => {
         race: null,
         stone: null,
         religion: 'Akatosh', // This is the original ID format
+        favoriteBlessing: null,
         traits: {
           regular: [],
           bonus: [],
@@ -258,6 +336,7 @@ describe('buildExportService', () => {
         race: null,
         stone: null,
         religion: 'unknown-religion',
+        favoriteBlessing: null,
         traits: {
           regular: [],
           bonus: [],
@@ -293,6 +372,100 @@ describe('buildExportService', () => {
 
       expect(hydratedData.religion.name).toBe('Unknown Religion')
       expect(hydratedData.religion.effects).toBe('No effects')
+    })
+
+    it('should resolve favorite blessing correctly', () => {
+      const mockBuild: BuildState = {
+        v: 1,
+        name: 'Test Character',
+        notes: '',
+        race: null,
+        stone: null,
+        religion: null,
+        favoriteBlessing: 'Akatosh',
+        traits: {
+          regular: [],
+          bonus: [],
+        },
+        traitLimits: {
+          regular: 2,
+          bonus: 1,
+        },
+        skills: {
+          major: [],
+          minor: [],
+        },
+        perks: {
+          selected: {},
+          ranks: {},
+        },
+        skillLevels: {},
+        equipment: [],
+        userProgress: {
+          unlocks: [],
+        },
+        destinyPath: [],
+        attributeAssignments: {
+          health: 0,
+          stamina: 0,
+          magicka: 0,
+          level: 1,
+          assignments: {},
+        },
+      }
+
+      const hydratedData = hydrateBuildData(mockBuild)
+
+      expect(hydratedData.favoriteBlessing.name).toBe('Blessing of Akatosh')
+      expect(hydratedData.favoriteBlessing.effects).toBe('Dragon Slayer, Time Reset')
+      expect(hydratedData.favoriteBlessing.source).toBe('Akatosh')
+    })
+
+    it('should handle missing favorite blessing gracefully', () => {
+      const mockBuild: BuildState = {
+        v: 1,
+        name: 'Test Character',
+        notes: '',
+        race: null,
+        stone: null,
+        religion: null,
+        favoriteBlessing: null,
+        traits: {
+          regular: [],
+          bonus: [],
+        },
+        traitLimits: {
+          regular: 2,
+          bonus: 1,
+        },
+        skills: {
+          major: [],
+          minor: [],
+        },
+        perks: {
+          selected: {},
+          ranks: {},
+        },
+        skillLevels: {},
+        equipment: [],
+        userProgress: {
+          unlocks: [],
+        },
+        destinyPath: [],
+        attributeAssignments: {
+          health: 0,
+          stamina: 0,
+          magicka: 0,
+          level: 1,
+          assignments: {},
+        },
+      }
+
+      const hydratedData = hydrateBuildData(mockBuild)
+
+      expect(hydratedData.favoriteBlessing.name).toBe('Not selected')
+      expect(hydratedData.favoriteBlessing.effects).toBe('No effects')
+      expect(hydratedData.favoriteBlessing.source).toBe('None')
     })
   })
 }) 

--- a/src/shared/types/discordExport.ts
+++ b/src/shared/types/discordExport.ts
@@ -11,6 +11,11 @@ export interface HydratedBuildData {
     followerBoon?: string;
     devoteeBoon?: string;
   }
+  favoriteBlessing: { 
+    name: string; 
+    effects: string;
+    source: string;
+  }
   skills: {
     major: Array<{ name: string; level?: number }>
     minor: Array<{ name: string; level?: number }>

--- a/src/shared/utils/__tests__/discordExportFormatter.test.ts
+++ b/src/shared/utils/__tests__/discordExportFormatter.test.ts
@@ -12,6 +12,7 @@ describe('discordExportFormatter', () => {
         birthSign: { name: 'Warrior', effects: 'Test effects' },
         traits: [],
         religion: { name: 'Akatosh', effects: 'Divine' },
+        favoriteBlessing: { name: 'Blessing of Akatosh', effects: 'Dragon Slayer, Time Reset', source: 'Akatosh' },
         skills: { major: [], minor: [], other: [] },
         perks: [],
         destinyPath: [],
@@ -29,6 +30,10 @@ describe('discordExportFormatter', () => {
 
       expect(result).toContain('__⚔️ Attributes (Level 5)__')
       expect(result).toContain('Health: 15, Stamina: 10, Magicka: 5')
+      expect(result).toContain('__✨ Favorite Blessing__')
+      expect(result).toContain('Blessing of Akatosh')
+      expect(result).toContain('• **Source:** Akatosh')
+      expect(result).toContain('• **Effects:** Dragon Slayer, Time Reset')
     })
 
     it('should handle builds with no attribute points', () => {
@@ -39,6 +44,7 @@ describe('discordExportFormatter', () => {
         birthSign: { name: 'Warrior', effects: 'Test effects' },
         traits: [],
         religion: { name: 'Akatosh', effects: 'Divine' },
+        favoriteBlessing: { name: 'Not selected', effects: 'No effects', source: 'None' },
         skills: { major: [], minor: [], other: [] },
         perks: [],
         destinyPath: [],
@@ -68,6 +74,7 @@ describe('discordExportFormatter', () => {
         birthSign: { name: 'Warrior', effects: 'Test effects' },
         traits: [],
         religion: { name: 'Akatosh', effects: 'Divine' },
+        favoriteBlessing: { name: 'Blessing of Akatosh', effects: 'Dragon Slayer, Time Reset', source: 'Akatosh' },
         skills: { major: [], minor: [], other: [] },
         perks: [],
         destinyPath: [],
@@ -85,6 +92,10 @@ describe('discordExportFormatter', () => {
 
       expect(result).toContain('__⚔️ Attributes (Level 5)__')
       expect(result).toContain('Health: 15, Stamina: 10, Magicka: 5')
+      expect(result).toContain('__✨ Favorite Blessing__')
+      expect(result).toContain('Blessing of Akatosh')
+      expect(result).toContain('• **Source:** Akatosh')
+      expect(result).toContain('• **Effects:** Dragon Slayer, Time Reset')
     })
 
     it('should handle builds with no attribute points', () => {
@@ -95,6 +106,7 @@ describe('discordExportFormatter', () => {
         birthSign: { name: 'Warrior', effects: 'Test effects' },
         traits: [],
         religion: { name: 'Akatosh', effects: 'Divine' },
+        favoriteBlessing: { name: 'Not selected', effects: 'No effects', source: 'None' },
         skills: { major: [], minor: [], other: [] },
         perks: [],
         destinyPath: [],

--- a/src/shared/utils/discordExportFormatter.ts
+++ b/src/shared/utils/discordExportFormatter.ts
@@ -57,6 +57,17 @@ export function formatBuildForDiscordNamesOnly(
   }
   lines.push('')
 
+  // Favorite Blessing
+  lines.push(`__✨ Favorite Blessing__`)
+  lines.push(`${data.favoriteBlessing.name}`)
+  if (data.favoriteBlessing.source !== 'None') {
+    lines.push(`• **Source:** ${data.favoriteBlessing.source}`)
+  }
+  if (data.favoriteBlessing.effects !== 'No effects') {
+    lines.push(`• **Effects:** ${data.favoriteBlessing.effects}`)
+  }
+  lines.push('')
+
   // NEW: Attributes
   lines.push(`__⚔️ Attributes (Level ${data.attributes.level})__`)
   const attributeParts = []
@@ -187,6 +198,17 @@ export function formatBuildForDiscord(
   }
   if (data.religion.devoteeBoon) {
     lines.push(`• **Devotee:** ${data.religion.devoteeBoon}`)
+  }
+  lines.push('')
+
+  // Favorite Blessing
+  lines.push(`__✨ Favorite Blessing__`)
+  lines.push(`${data.favoriteBlessing.name}`)
+  if (data.favoriteBlessing.source !== 'None') {
+    lines.push(`• **Source:** ${data.favoriteBlessing.source}`)
+  }
+  if (data.favoriteBlessing.effects !== 'No effects') {
+    lines.push(`• **Effects:** ${data.favoriteBlessing.effects}`)
   }
   lines.push('')
 


### PR DESCRIPTION
- Add favoriteBlessing to URL sync dependency array for URL persistence

- Extend HydratedBuildData interface to include favorite blessing data

- Implement resolveFavoriteBlessing function in build export service

- Add favorite blessing section to Discord export formats (short and long)

- Add comprehensive tests for favorite blessing resolution and export

- Update all test mocks to include favorite blessing data