### PR TITLE
fix(build): correct broken 'View all' navigation links

### DIFF
--- a/src/features/birthsigns/components/BirthsignSelectionCard.tsx
+++ b/src/features/birthsigns/components/BirthsignSelectionCard.tsx
@@ -31,7 +31,7 @@ export function BirthsignSelectionCard({
   }
 
   const handleNavigateToBirthsignPage = () => {
-    navigate('/birth-signs')
+    navigate('/build/birth-signs')
   }
 
   // If no birthsign is selected, show the autocomplete

--- a/src/features/skills/components/view/BuildPageSkillCard.tsx
+++ b/src/features/skills/components/view/BuildPageSkillCard.tsx
@@ -42,7 +42,7 @@ export function BuildPageSkillCard({ className }: BuildPageSkillCardProps) {
   const [perkTreeOpen, setPerkTreeOpen] = useState(false)
 
   const handleNavigateToSkillPage = () => {
-    navigate('/skills')
+    navigate('/build/perks')
   }
 
   const handleSkillClick = (skillId: string) => {

--- a/src/features/traits/components/TraitSelectionCard.tsx
+++ b/src/features/traits/components/TraitSelectionCard.tsx
@@ -1,5 +1,6 @@
-import { useCharacterBuild } from '@/shared/hooks/useCharacterBuild'
+import { FormattedText } from '@/shared/components/generic/FormattedText'
 import { SelectionCardShell } from '@/shared/components/ui'
+import { useCharacterBuild } from '@/shared/hooks/useCharacterBuild'
 import { Badge } from '@/shared/ui/ui/badge'
 import { Button } from '@/shared/ui/ui/button'
 import { X } from 'lucide-react'
@@ -7,7 +8,6 @@ import { useNavigate } from 'react-router-dom'
 import { useTraits } from '../hooks/useTraits'
 import type { Trait } from '../types'
 import { TraitAutocomplete } from './'
-import { FormattedText } from '@/shared/components/generic/FormattedText'
 
 interface TraitSelectionCardProps {
   className?: string
@@ -45,7 +45,7 @@ export function TraitSelectionCard({ className }: TraitSelectionCardProps) {
   }
 
   const handleNavigateToTraitPage = () => {
-    navigate('/traits')
+    navigate('/build/traits')
   }
 
   // Filter out already selected traits from autocomplete options


### PR DESCRIPTION
- Fix TraitSelectionCard: /traits -> /build/traits
- Fix BirthsignSelectionCard: /birth-signs -> /build/birth-signs
- Fix BuildPageSkillCard: /skills -> /build/perks

All 'View all' links now properly navigate within the character build flow.